### PR TITLE
Add runnable questing sample

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+from src.session_manager import run_session_check
+from src.credit_tracker import track_credits
+from src.log_manager import start_log
+from src.mode_questing import start_questing
+
+
+def main():
+    print("\U0001F6F0\uFE0F MorningStar MS11 Initialized")
+    print("\U0001F4CC Mode: QUESTING TEST")
+
+    start_log()
+    run_session_check()
+    track_credits()
+
+    print("\U0001F680 Initiating Questing Mode...")
+    completed_quests = start_questing(character_name="Vornax")
+    print(f"\U0001F4D8 Questing Session Summary: {len(completed_quests)} steps completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/credit_tracker.py
+++ b/src/credit_tracker.py
@@ -1,0 +1,6 @@
+"""Track in-game credits."""
+
+def track_credits():
+    """Placeholder to track credit balance."""
+    print("Credits tracked.")
+    return 0

--- a/src/log_manager.py
+++ b/src/log_manager.py
@@ -1,0 +1,5 @@
+"""Manage log output for MorningStar."""
+
+def start_log():
+    """Placeholder to initialize logging."""
+    print("Log started.")

--- a/src/mode_questing.py
+++ b/src/mode_questing.py
@@ -1,0 +1,8 @@
+"""Questing mode utilities."""
+
+def start_questing(character_name: str):
+    """Placeholder to simulate questing steps."""
+    print(f"Questing for {character_name}...")
+    # In a real implementation this would run game automation
+    steps = ["start", "finish"]
+    return steps

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1,0 +1,6 @@
+"""Manage questing sessions."""
+
+def run_session_check():
+    """Placeholder to check session status."""
+    print("Session check complete.")
+    return True


### PR DESCRIPTION
## Summary
- implement stub modules for logging, sessions, credits, and questing
- add a sample main program demonstrating a questing workflow

## Testing
- `python3 main.py`
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r ms11-core/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6850e1191d40833198d4592977fcbff2