### PR TITLE
Add story generator tests

### DIFF
--- a/src/story_generator.py
+++ b/src/story_generator.py
@@ -1,0 +1,12 @@
+from langchain import LLMChain, PromptTemplate
+from langchain.llms import HuggingFacePipeline
+from transformers import pipeline
+
+
+def generate_story(prompt: str, model_name: str = "gpt2") -> str:
+    """Generate a short story using a HuggingFace model via LangChain."""
+    text_gen = pipeline("text-generation", model=model_name)
+    hf_llm = HuggingFacePipeline(pipeline=text_gen)
+    template = PromptTemplate.from_template("{prompt}")
+    chain = LLMChain(prompt=template, llm=hf_llm)
+    return chain.run(prompt)

--- a/tests/test_story_generator.py
+++ b/tests/test_story_generator.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch, ANY
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.story_generator import generate_story
+
+
+@patch('src.story_generator.LLMChain')
+@patch('src.story_generator.HuggingFacePipeline')
+@patch('src.story_generator.pipeline')
+def test_generate_story_uses_default_model(pipeline_mock, hf_mock, llmchain_mock):
+    prompt = "Once upon a time"
+    expected = "A brave hero emerged."
+
+    # Mock pipeline from transformers
+    fake_pipeline = MagicMock()
+    pipeline_mock.return_value = fake_pipeline
+
+    # Mock HuggingFacePipeline to return an object used by LLMChain
+    hf_instance = MagicMock()
+    hf_mock.return_value = hf_instance
+
+    # Mock LLMChain.run to return expected text
+    chain_instance = MagicMock()
+    chain_instance.run.return_value = expected
+    llmchain_mock.return_value = chain_instance
+
+    result = generate_story(prompt)
+
+    pipeline_mock.assert_called_once_with('text-generation', model='gpt2')
+    hf_mock.assert_called_once_with(pipeline=fake_pipeline)
+    llmchain_mock.assert_called_once_with(prompt=ANY, llm=hf_instance)
+    chain_instance.run.assert_called_once_with(prompt)
+
+    assert result == expected
+
+
+@patch('src.story_generator.LLMChain')
+@patch('src.story_generator.HuggingFacePipeline')
+@patch('src.story_generator.pipeline')
+def test_generate_story_custom_model(pipeline_mock, hf_mock, llmchain_mock):
+    prompt = "In a galaxy"
+    model = "distilgpt2"
+    expected = "far away..."
+
+    fake_pipeline = MagicMock()
+    pipeline_mock.return_value = fake_pipeline
+
+    hf_instance = MagicMock()
+    hf_mock.return_value = hf_instance
+
+    chain_instance = MagicMock()
+    chain_instance.run.return_value = expected
+    llmchain_mock.return_value = chain_instance
+
+    result = generate_story(prompt, model_name=model)
+
+    pipeline_mock.assert_called_once_with('text-generation', model=model)
+    hf_mock.assert_called_once_with(pipeline=fake_pipeline)
+    llmchain_mock.assert_called_once_with(prompt=ANY, llm=hf_instance)
+    chain_instance.run.assert_called_once_with(prompt)
+
+    assert result == expected


### PR DESCRIPTION
## Summary
- implement a `generate_story` helper that uses LangChain + HuggingFace
- add unit tests with mocking for the network-based features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851cc73003083318da9731450357554