### PR TITLE
Add version flag and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Project-MorningStar
+Version: 0.1.0
 Project MorningStar (formerly known as MS11-Core) is an advanced interface assistant for long-session open-world automation. Inspired by player realism, faction-based systems, and strategic progression loops.
 
 The original MS11-Core implementation has been archived under `archive/ms11-core` to preserve legacy code.

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+from src.xp_manager import XPManager
+
+
+def get_version_from_readme() -> str:
+    """Extract the version string from the README.md file."""
+    readme_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
+    with open(readme_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip().lower().startswith("version"):
+                return line.split(":", 1)[-1].strip()
+    return "unknown"
+
+
+def run_mode(mode: str):
+    print(f"[\U0001F30C] MorningStar Runner Active: Mode = {mode}")
+    xp = XPManager(character="Ezra")
+
+    if mode == "quest":
+        xp.record_action("quest_complete")
+    elif mode == "grind":
+        xp.record_action("mob_kill")
+    elif mode == "heal":
+        xp.record_action("healing_tick")
+    else:
+        print("[\u26A0\uFE0F] Unknown mode selected.")
+
+    xp.end_session()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MorningStar Core Runner")
+    parser.add_argument("--mode", type=str, default="quest", help="Choose a mode: quest, grind, heal")
+    parser.add_argument("--version", action="store_true", help="Show application version and exit")
+    args = parser.parse_args()
+
+    if args.version:
+        print(get_version_from_readme())
+        return
+
+    run_mode(args.mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,16 @@
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src import runner
+
+
+def test_version_option_prints_version(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--version"])
+    # Reload to ensure argparse parses the new argv
+    reload(runner)
+    runner.main()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "0.1.0"


### PR DESCRIPTION
## Summary
- create `runner.py` script with `--version` flag
- record version in README
- add tests for the new CLI flag

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68522314ad7883318023120d8cd373c2