### PR TITLE
Add debug mode and logger utility

### DIFF
--- a/src/logger_utils.py
+++ b/src/logger_utils.py
@@ -1,0 +1,18 @@
+"""Logging utilities for MorningStar."""
+import os
+from typing import List
+
+DEFAULT_LOG_PATH = "ms.log"
+
+def read_logs(path: str = DEFAULT_LOG_PATH, num_lines: int = 5) -> List[str]:
+    """Return the last ``num_lines`` lines from ``path``.
+
+    If the file does not exist, an empty list is returned.
+    """
+    if not os.path.exists(path):
+        return []
+
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    return [line.rstrip("\n") for line in lines[-num_lines:]]

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from src.xp_manager import XPManager
+from src.logger_utils import read_logs, DEFAULT_LOG_PATH
 
 
 def get_version_from_readme() -> str:
@@ -15,6 +16,15 @@ def get_version_from_readme() -> str:
 
 def run_mode(mode: str):
     print(f"[\U0001F30C] MorningStar Runner Active: Mode = {mode}")
+    if mode == "debug":
+        lines = read_logs(DEFAULT_LOG_PATH, num_lines=5)
+        if not lines:
+            print("[\u26A0\uFE0F] No logs to display.")
+        else:
+            for line in lines:
+                print(line)
+        return
+
     xp = XPManager(character="Ezra")
 
     if mode == "quest":
@@ -31,7 +41,7 @@ def run_mode(mode: str):
 
 def main():
     parser = argparse.ArgumentParser(description="MorningStar Core Runner")
-    parser.add_argument("--mode", type=str, default="quest", help="Choose a mode: quest, grind, heal")
+    parser.add_argument("--mode", type=str, default="quest", help="Choose a mode: quest, grind, heal, debug")
     parser.add_argument("--version", action="store_true", help="Show application version and exit")
     args = parser.parse_args()
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,3 +14,20 @@ def test_version_option_prints_version(capsys, monkeypatch):
     runner.main()
     captured = capsys.readouterr()
     assert captured.out.strip() == "0.1.0"
+
+def test_debug_mode_replays_logs(monkeypatch, capsys):
+    lines = ["line1", "line2", "line3", "line4", "line5"]
+
+    def fake_read_logs(path, num_lines=5):
+        assert path == "ms.log"
+        assert num_lines == 5
+        return lines
+
+    monkeypatch.setattr(sys, "argv", ["prog", "--mode", "debug"])
+    reload(runner)
+    monkeypatch.setattr(runner, "read_logs", fake_read_logs)
+    monkeypatch.setattr(runner, "DEFAULT_LOG_PATH", "ms.log", raising=False)
+    runner.main()
+    captured = capsys.readouterr()
+    for l in lines:
+        assert l in captured.out


### PR DESCRIPTION
## Summary
- implement `logger_utils.read_logs` for displaying log tail
- add `debug` mode to CLI runner
- document debug mode behavior with test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852309ac03883319694822635877c2f