### PR TITLE
Implement CLI mode dispatcher

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -1,5 +1,7 @@
 import argparse
 import os
+from typing import Callable, Dict
+
 from src.xp_manager import XPManager
 from src.logger_utils import read_logs, DEFAULT_LOG_PATH
 
@@ -14,7 +16,17 @@ def get_version_from_readme() -> str:
     return "unknown"
 
 
-def run_mode(mode: str):
+# Mapping of mode name to a callable that performs the action for that mode.
+# Each callable accepts an ``XPManager`` instance as its only argument.
+MODE_DISPATCH: Dict[str, Callable[[XPManager], None]] = {
+    "quest": lambda xp: xp.record_action("quest_complete"),
+    "grind": lambda xp: xp.record_action("mob_kill"),
+    "heal": lambda xp: xp.record_action("healing_tick"),
+}
+
+
+def run_mode(mode: str) -> None:
+    """Run the specified mode."""
     print(f"[\U0001F30C] MorningStar Runner Active: Mode = {mode}")
     if mode == "debug":
         lines = read_logs(DEFAULT_LOG_PATH, num_lines=5)
@@ -27,12 +39,9 @@ def run_mode(mode: str):
 
     xp = XPManager(character="Ezra")
 
-    if mode == "quest":
-        xp.record_action("quest_complete")
-    elif mode == "grind":
-        xp.record_action("mob_kill")
-    elif mode == "heal":
-        xp.record_action("healing_tick")
+    action = MODE_DISPATCH.get(mode)
+    if action:
+        action(xp)
     else:
         print("[\u26A0\uFE0F] Unknown mode selected.")
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -31,3 +31,22 @@ def test_debug_mode_replays_logs(monkeypatch, capsys):
     captured = capsys.readouterr()
     for l in lines:
         assert l in captured.out
+
+
+def test_run_mode_dispatches(monkeypatch):
+    calls = []
+
+    class FakeXP:
+        def __init__(self, character):
+            pass
+
+        def record_action(self, action):
+            calls.append(action)
+
+        def end_session(self):
+            calls.append("end")
+
+    monkeypatch.setattr(runner, "XPManager", FakeXP)
+    monkeypatch.setattr(runner, "MODE_DISPATCH", {"quest": lambda xp: xp.record_action("quest_complete")})
+    runner.run_mode("quest")
+    assert calls == ["quest_complete", "end"]


### PR DESCRIPTION
## Summary
- add a `MODE_DISPATCH` mapping in `src/runner.py`
- update `run_mode` to use the dispatcher
- test new dispatcher behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852327936ec8331a26521f41a34b20c