### PR TITLE
Add unit tests for XPManager and DB queries

### DIFF
--- a/tests/test_next_quest.py
+++ b/tests/test_next_quest.py
@@ -1,11 +1,20 @@
-from src.db.quest_utils import get_next_quest_in_chain
+import os
+import sys
+from unittest.mock import MagicMock
 
-chain_id = 1
-current_step = 1  # adjust based on your test data
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-next_quest = get_next_quest_in_chain(chain_id, current_step)
+from src.db import quest_utils
 
-if next_quest:
-    print("✅ Next quest found:", next_quest)
-else:
-    print("❌ No next quest found.")
+
+def test_get_next_quest_in_chain(monkeypatch):
+    fake_cursor = MagicMock()
+    fake_cursor.fetchone.return_value = {"id": 2}
+    fake_conn = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+    monkeypatch.setattr(quest_utils, 'get_connection', lambda: fake_conn)
+
+    result = quest_utils.get_next_quest_in_chain(1, 1)
+    assert result == {"id": 2}
+    fake_cursor.execute.assert_called()
+    fake_conn.close.assert_called_once()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,20 +1,21 @@
 import os
 import sys
 from unittest.mock import MagicMock
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from src.db import quest_utils
+from src.db import queries
 
 
-def test_log_progress(monkeypatch):
+def test_select_best_quest(monkeypatch):
     fake_cursor = MagicMock()
+    fake_cursor.fetchone.return_value = (1, 'Q', '[]')
     fake_conn = MagicMock()
     fake_conn.cursor.return_value = fake_cursor
-    monkeypatch.setattr(quest_utils, 'get_connection', lambda: fake_conn)
+    monkeypatch.setattr(queries, 'get_connection', lambda: fake_conn)
 
-    quest_utils.log_progress("PlayerX", 3, completed=True)
-
+    result = queries.select_best_quest('Hero')
+    assert result == (1, 'Q', '[]')
     fake_cursor.execute.assert_called()
-    fake_conn.commit.assert_called_once()
     fake_conn.close.assert_called_once()

--- a/tests/test_xp_manager.py
+++ b/tests/test_xp_manager.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest.mock import MagicMock
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.xp_manager import XPManager
+
+
+def test_end_session_prints_path(monkeypatch, capsys):
+    fake_session = MagicMock()
+    fake_session.save.return_value = "/tmp/foo.json"
+    monkeypatch.setattr('src.xp_manager.XPSession', MagicMock(return_value=fake_session))
+
+    manager = XPManager("Hero")
+    manager.end_session()
+    captured = capsys.readouterr()
+    assert "XP session saved to: /tmp/foo.json" in captured.out
+    fake_session.finalize.assert_called_once()
+    fake_session.save.assert_called_once()


### PR DESCRIPTION
## Summary
- convert example scripts under `tests/` into real pytest tests
- add unit tests for `XPManager.end_session` message
- add unit tests for `queries.select_best_quest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68567d468b6883319eda1b716f8dabe0