### PR TITLE
Add notes management utilities

### DIFF
--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -32,3 +32,51 @@ def insert_quest(character, title, steps):
     conn.commit()
     conn.close()
     print(f"✅ Quest inserted for {character}: {title}")
+
+
+def insert_note(character: str, topic: str, content: str):
+    """Insert a note for a given character."""
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+            INSERT INTO notes (character, topic, content)
+            VALUES (?, ?, ?)
+        """,
+        (character, topic, content),
+    )
+
+    conn.commit()
+    conn.close()
+
+
+def get_notes(character: str, topic: str | None = None):
+    """Retrieve notes for a character, optionally filtered by topic."""
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    if topic is None:
+        cursor.execute(
+            """
+                SELECT id, character, topic, content, created_at
+                FROM notes
+                WHERE character = ?
+                ORDER BY created_at DESC
+            """,
+            (character,),
+        )
+    else:
+        cursor.execute(
+            """
+                SELECT id, character, topic, content, created_at
+                FROM notes
+                WHERE character = ? AND topic = ?
+                ORDER BY created_at DESC
+            """,
+            (character, topic),
+        )
+
+    rows = cursor.fetchall()
+    conn.close()
+    return rows

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.db import queries
+
+
+def test_insert_note(monkeypatch):
+    fake_cursor = MagicMock()
+    fake_conn = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+    monkeypatch.setattr(queries, "get_connection", lambda: fake_conn)
+
+    queries.insert_note("Hero", "tips", "use force")
+
+    fake_cursor.execute.assert_called()
+    fake_conn.commit.assert_called_once()
+    fake_conn.close.assert_called_once()
+
+
+def test_get_notes(monkeypatch):
+    expected = [(1, "Hero", "tips", "note", "2024-01-01")]
+    fake_cursor = MagicMock()
+    fake_cursor.fetchall.return_value = expected
+    fake_conn = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+    monkeypatch.setattr(queries, "get_connection", lambda: fake_conn)
+
+    result = queries.get_notes("Hero")
+
+    fake_cursor.execute.assert_called()
+    fake_conn.close.assert_called_once()
+    assert result == expected
+
+
+def test_get_notes_filtered(monkeypatch):
+    fake_cursor = MagicMock()
+    fake_cursor.fetchall.return_value = []
+    fake_conn = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+    monkeypatch.setattr(queries, "get_connection", lambda: fake_conn)
+
+    result = queries.get_notes("Hero", topic="tips")
+
+    fake_cursor.execute.assert_called()
+    fake_conn.close.assert_called_once()
+    assert result == []


### PR DESCRIPTION
## Summary
- extend `src/db/queries.py` with `insert_note` and `get_notes`
- add unit tests for notes utilities
- install requirements for test run

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857d14d02648331a9d41d7dc4c1a16d