### PR TITLE
Fix quest primary key

### DIFF
--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -8,7 +8,7 @@ def select_best_quest(character_name: str):
 
     # Prioritize official, validated quests
     cursor.execute("""
-        SELECT quest_id, title, steps
+        SELECT id, title, steps
         FROM quests
         WHERE validated = 1 AND source_type = 'official' AND character = ?
         ORDER BY fallback_rank ASC

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS quests (
-    quest_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     character TEXT,
     title TEXT,
     steps TEXT,

--- a/src/db/view_quests.py
+++ b/src/db/view_quests.py
@@ -13,8 +13,8 @@ def view_all_quests():
     else:
         print(f"✅ Retrieved {len(rows)} quest(s):\n")
         for row in rows:
-            quest_id, character, title, steps, source_type, validated, fallback_rank, chain_id, step_number = row
-            print(f"🧾 Quest ID: {quest_id}")
+            id, character, title, steps, source_type, validated, fallback_rank, chain_id, step_number = row
+            print(f"🧾 Quest ID: {id}")
             print(f"👤 Character: {character}")
             print(f"📌 Title: {title}")
             print(f"📜 Steps: {json.loads(steps)}")


### PR DESCRIPTION
## Summary
- standardize quests primary key as `id`
- update DB queries and viewer accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857d45b42548331a44e0156611526db