### PR TITLE
Implement quest executor with status tracking

### DIFF
--- a/src/quest_executor.py
+++ b/src/quest_executor.py
@@ -1,13 +1,41 @@
 """Helpers for running quest steps."""
 
-from typing import Any
+from typing import Any, Dict
 
 
-def execute_quest(quest: Any) -> None:
+def execute_quest(quest: Any, *, dry_run: bool = False) -> Dict[str, bool]:
     """Execute the given ``quest``.
 
-    Currently a stub that prints the quest and returns ``None``.
+    Parameters
+    ----------
+    quest:
+        The quest data which should contain a ``steps`` sequence.
+    dry_run:
+        If ``True`` no real automation is performed. Instead, each step is
+        logged as if it were executed. This is useful for testing.
+
+    Returns
+    -------
+    dict
+        Status flags for the quest execution containing ``in_progress``,
+        ``completed`` and ``failed`` keys.
     """
     print(f"[DEBUG] Executing quest: {quest}")
-    # TODO: iterate over quest steps and perform automation
-    return None
+
+    status = {"in_progress": True, "completed": False, "failed": False}
+    steps = getattr(quest, "steps", None) or quest.get("steps", []) if isinstance(quest, dict) else []
+
+    try:
+        for idx, step in enumerate(steps, start=1):
+            prefix = "DRY-RUN" if dry_run else "STEP"
+            print(f"[{prefix}] {idx}: {step}")
+            # Real automation would occur here in non-dry-run mode
+
+        status["completed"] = True
+    except Exception as exc:  # pragma: no cover - unexpected failures
+        print(f"[ERROR] {exc}")
+        status["failed"] = True
+    finally:
+        status["in_progress"] = False
+
+    return status

--- a/tests/test_quest_executor.py
+++ b/tests/test_quest_executor.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.quest_executor import execute_quest
+
+
+def test_execute_quest_order(capsys):
+    quest = {"title": "Demo", "steps": ["one", "two", "three"]}
+    status = execute_quest(quest, dry_run=True)
+    captured = capsys.readouterr()
+    lines = captured.out.strip().splitlines()
+    expected_lines = [
+        "[DEBUG] Executing quest: {'title': 'Demo', 'steps': ['one', 'two', 'three']}",
+        "[DRY-RUN] 1: one",
+        "[DRY-RUN] 2: two",
+        "[DRY-RUN] 3: three",
+    ]
+    assert lines == expected_lines
+    assert status == {"in_progress": False, "completed": True, "failed": False}
+


### PR DESCRIPTION
## Summary
- expand `execute_quest` to iterate over steps and support dry runs
- return quest status flags so callers can check completion
- add unit test verifying quest step execution order

## Testing
- `pytest tests/test_quest_executor.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_b_68583e50333083318ed9a1eca0ba0b76