### PR TITLE
Add file hash detection for legacy HTML

### DIFF
--- a/src/importers/legacy_quest_parser.py
+++ b/src/importers/legacy_quest_parser.py
@@ -1,11 +1,19 @@
 import os
 import json
+from pathlib import Path
 from bs4 import BeautifulSoup
+
+from src.source_verifier import file_changed
 
 RAW_HTML_PATH = "data/raw/legacy.html"
 OUTPUT_JSON_PATH = "data/processed/legacy_quests.json"
+HASH_PATH = Path(RAW_HTML_PATH).with_suffix(".hash")
 
 def parse_legacy_quest_html():
+    if not file_changed(RAW_HTML_PATH, HASH_PATH):
+        print("ℹ️ legacy.html unchanged, skipping parse")
+        return
+
     with open(RAW_HTML_PATH, "r", encoding="utf-8") as f:
         html = f.read()
 

--- a/src/source_verifier.py
+++ b/src/source_verifier.py
@@ -1,6 +1,42 @@
-"""Simple quest source verification utilities."""
+"""Utilities for verifying quest sources and detecting file changes."""
 
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
 from typing import Any
+
+DEFAULT_HASH_PATH = Path("data/raw/legacy.hash")
+
+
+def compute_file_hash(path: str | Path) -> str:
+    """Return a SHA256 hash of the given file."""
+    file_path = Path(path)
+    hasher = hashlib.sha256()
+    with file_path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def file_changed(path: str | Path, hash_path: str | Path = DEFAULT_HASH_PATH) -> bool:
+    """Return ``True`` if ``path`` differs from the stored hash.
+
+    The current hash will be written to ``hash_path`` whenever the file has
+    changed or no previous hash exists.
+    """
+
+    file_path = Path(path)
+    hash_file = Path(hash_path)
+
+    current = compute_file_hash(file_path)
+    if hash_file.exists():
+        previous = hash_file.read_text().strip()
+        if previous == current:
+            return False
+
+    hash_file.write_text(current)
+    return True
 
 
 def verify_source(data: Any) -> bool:

--- a/tests/test_source_verifier.py
+++ b/tests/test_source_verifier.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.source_verifier import file_changed
+
+
+def test_file_changed_detects_modifications(tmp_path):
+    html_path = tmp_path / "legacy.html"
+    hash_path = tmp_path / "legacy.hash"
+
+    html_path.write_text("first")
+    assert file_changed(html_path, hash_path) is True
+
+    # No change should return False
+    assert file_changed(html_path, hash_path) is False
+
+    # Modify file and ensure change is detected
+    html_path.write_text("second")
+    assert file_changed(html_path, hash_path) is True

--- a/utils/source_verifier.py
+++ b/utils/source_verifier.py
@@ -1,12 +1,40 @@
-"""Placeholder helpers for verifying quest sources."""
+"""Helpers for verifying external quest sources with file hashing."""
 
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
 from typing import Any
+
+DEFAULT_HASH_PATH = Path("data/raw/legacy.hash")
+
+
+def compute_file_hash(path: str | Path) -> str:
+    """Return a SHA256 hash for ``path``."""
+    file_path = Path(path)
+    hasher = hashlib.sha256()
+    with file_path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def file_changed(path: str | Path, hash_path: str | Path = DEFAULT_HASH_PATH) -> bool:
+    """Return ``True`` if the file differs from the stored hash."""
+    file_path = Path(path)
+    hash_file = Path(hash_path)
+
+    current = compute_file_hash(file_path)
+    if hash_file.exists():
+        previous = hash_file.read_text().strip()
+        if previous == current:
+            return False
+
+    hash_file.write_text(current)
+    return True
 
 
 def verify_source(data: Any) -> bool:
-    """Validate external quest ``data``.
-
-    Returns ``False`` until real verification logic is added.
-    """
+    """Validate external quest ``data``."""
     # TODO: implement checksum or schema checks
     return False


### PR DESCRIPTION
## Summary
- store legacy HTML hash to avoid reparsing unchanged data
- add hashing helpers in `source_verifier` modules
- skip parsing when `legacy.html` didn't change
- test file change detection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68583e56e5108331a3e86c60a2e1ab0d