### PR TITLE
Add hashing check to verify_source

### DIFF
--- a/src/source_verifier.py
+++ b/src/source_verifier.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_HASH_PATH = Path("data/raw/legacy.hash")
+TRUSTED_HASHES = {
+    "247391101e29decad45551f0c515abb2bd8286393e579ac12e22eec57b89b3b2"
+}
 
 
 def compute_file_hash(path: str | Path) -> str:
@@ -42,5 +45,13 @@ def file_changed(path: str | Path, hash_path: str | Path = DEFAULT_HASH_PATH) ->
 def verify_source(data: Any) -> bool:
     """Return ``True`` if ``data`` appears trustworthy."""
     print(f"[DEBUG] Verifying quest source: {data}")
-    # TODO: implement real signature or hash checks
-    return True
+
+    if isinstance(data, (str, Path)) and Path(data).exists():
+        hash_value = compute_file_hash(Path(data))
+    elif isinstance(data, bytes):
+        hash_value = hashlib.sha256(data).hexdigest()
+    else:
+        hash_value = hashlib.sha256(str(data).encode()).hexdigest()
+
+    print(f"[DEBUG] Computed hash: {hash_value}")
+    return hash_value in TRUSTED_HASHES

--- a/tests/test_source_verifier.py
+++ b/tests/test_source_verifier.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from src.source_verifier import file_changed
+from src.source_verifier import file_changed, verify_source
 
 
 def test_file_changed_detects_modifications(tmp_path):
@@ -20,3 +20,16 @@ def test_file_changed_detects_modifications(tmp_path):
     # Modify file and ensure change is detected
     html_path.write_text("second")
     assert file_changed(html_path, hash_path) is True
+
+
+def test_verify_source_with_string():
+    assert verify_source("trusted_data") is True
+    assert verify_source("untrusted") is False
+
+
+def test_verify_source_with_file(tmp_path):
+    p = tmp_path / "data.txt"
+    p.write_text("trusted_data")
+    assert verify_source(p) is True
+    p.write_text("evil")
+    assert verify_source(p) is False


### PR DESCRIPTION
## Summary
- extend `verify_source` to calculate a hash and check against trusted values
- test `verify_source` with strings and files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859694b7d0083318d345eeda70358fb