### PR TITLE
Consolidate source verifier reference

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -4,11 +4,11 @@
 - **XP tracking**: `xp_manager.py`, `xp_session.py`, and `xp_tracker.py` allow recording actions and saving session logs.
 - **Mode runner**: `main.py` and `runner.py` provide CLI entry points to launch different automation modes.
 - **Quest database**: `src/db` holds SQLite schema, quest insertion helpers, and utilities for viewing quests.
+- **Source verifier**: `src/source_verifier.py` validates quest data and detects file changes.
 
 ## Modules Needing Work
 - `quest_selector.py` – now includes `select_quest()` stub returning `None`; needs real selection logic.
 - `quest_executor.py` – provides `execute_quest()` placeholder; expand with automation steps.
-- `src/source_verifier.py` – provides helpers for verifying quest data and detecting file changes.
 
 ## Planned Improvements
 - Implement quest selection logic using user preferences and DB rankings.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Three lightweight helpers provide a basic quest pipeline:
 
 - `quest_selector.select_quest` picks the next mission for a character.
 - `quest_executor.execute_quest` iterates through the quest steps.
-- `source_verifier.verify_source` checks that the data you loaded is trustworthy.
+- `src.source_verifier.verify_source` checks that the data you loaded is trustworthy.
 
 ```python
 from src.quest_selector import select_quest

--- a/utils/source_verifier.py
+++ b/utils/source_verifier.py
@@ -1,0 +1,13 @@
+"""Compatibility wrapper for the source verifier helpers."""
+
+from src.source_verifier import (
+    compute_file_hash,
+    file_changed,
+    verify_source,
+)
+
+__all__ = [
+    "compute_file_hash",
+    "file_changed",
+    "verify_source",
+]


### PR DESCRIPTION
## Summary
- make README explicit about `src.source_verifier`
- note source verifier functionality in NOTES
- add a thin wrapper in `utils/` for backward compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68597bd70c148331a6ea4ea9765bff83