### PR TITLE
Add quest execution CLI

### DIFF
--- a/scripts/cli/execute_quest.py
+++ b/scripts/cli/execute_quest.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+import os
+from datetime import datetime
+
+from src.quest_selector import select_quest
+
+DEFAULT_LOG_PATH = os.path.join("logs", "quest_selections.log")
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Quest selection utility")
+    parser.add_argument("--character", required=True, help="Character name")
+    parser.add_argument("--planet", help="Filter by planet")
+    parser.add_argument("--type", dest="quest_type", help="Filter by quest type")
+    parser.add_argument("--random", action="store_true", help="Choose randomly among options")
+    parser.add_argument("--debug", action="store_true", help="Print raw quest data")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    quest = select_quest(
+        args.character,
+        planet=args.planet,
+        quest_type=args.quest_type,
+        randomize=args.random,
+    )
+
+    if quest is None:
+        print("\u26A0\ufe0f No eligible quest found.")
+        return None
+
+    if args.debug:
+        print(quest)
+    else:
+        title = quest.get("title", "Unknown")
+        planet = quest.get("planet", "Unknown")
+        qtype = quest.get("type", "?")
+        print(f"{title} - {planet} [{qtype}]")
+
+    os.makedirs(os.path.dirname(DEFAULT_LOG_PATH), exist_ok=True)
+    timestamp = datetime.now().isoformat()
+    with open(DEFAULT_LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(f"{timestamp} - {json.dumps(quest)}\n")
+    return quest
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_execute_quest_cli.py
+++ b/tests/test_execute_quest_cli.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.cli import execute_quest
+
+
+def test_cli_selects_and_logs(monkeypatch, tmp_path, capsys):
+    quest = {"title": "Q1", "planet": "Naboo", "type": "Hero"}
+    log_path = tmp_path / "quest.log"
+
+    monkeypatch.setattr(sys, "argv", ["prog", "--character", "Ezra"])
+    reload(execute_quest)
+    monkeypatch.setattr(execute_quest, "select_quest", lambda *a, **k: quest)
+    monkeypatch.setattr(execute_quest, "DEFAULT_LOG_PATH", str(log_path), raising=False)
+    execute_quest.main()
+
+    captured = capsys.readouterr()
+    assert "Q1" in captured.out
+    assert log_path.exists()
+    assert "Q1" in log_path.read_text()
+
+
+def test_cli_no_quest(monkeypatch, tmp_path, capsys):
+    log_path = tmp_path / "quest.log"
+    monkeypatch.setattr(sys, "argv", ["prog", "--character", "Ezra"])
+    reload(execute_quest)
+    monkeypatch.setattr(execute_quest, "select_quest", lambda *a, **k: None)
+    monkeypatch.setattr(execute_quest, "DEFAULT_LOG_PATH", str(log_path), raising=False)
+    execute_quest.main()
+
+    captured = capsys.readouterr()
+    assert "No eligible quest" in captured.out
+    assert not log_path.exists()


### PR DESCRIPTION
## Summary
- add a small CLI for choosing a quest
- write tests for the CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859f5578ed4833180b796cedfd96251