### PR TITLE
Add quest mode CLI selector

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,0 +1,27 @@
+import argparse
+from src.quest_selector import get_random_quest
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Random quest selector")
+    parser.add_argument(
+        "--quest-mode",
+        type=str,
+        required=True,
+        help="Choose quest mode: legacy, ground, mustafar, themeparks, etc.",
+    )
+    args = parser.parse_args(argv)
+
+    quest = get_random_quest(args.quest_mode)
+    if quest:
+        name = quest.get("name") or quest.get("title", "Unknown")
+        description = quest.get("description") or quest.get("steps", "")
+        if isinstance(description, list):
+            description = description[0] if description else ""
+        print(f"\n\U0001F9ED Starting Quest:\n{name} - {description}")
+    else:
+        print("\u26A0\ufe0f No quests found for the selected mode.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_random_quest_cli.py
+++ b/tests/test_random_quest_cli.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cli import main as quest_cli
+
+
+def test_cli_prints_random_quest(monkeypatch, capsys):
+    sample = {"name": "Heroic Quest", "description": "Do heroic things"}
+    monkeypatch.setattr(sys, "argv", ["prog", "--quest-mode", "legacy"])
+    reload(quest_cli)
+    monkeypatch.setattr(quest_cli, "get_random_quest", lambda mode: sample)
+    quest_cli.main()
+    out = capsys.readouterr().out
+    assert "Heroic Quest" in out
+
+
+def test_cli_handles_no_results(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "--quest-mode", "legacy"])
+    reload(quest_cli)
+    monkeypatch.setattr(quest_cli, "get_random_quest", lambda mode: None)
+    quest_cli.main()
+    out = capsys.readouterr().out
+    assert "No quests found" in out

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,11 @@
+import os
+
+
+def get_db_connection():
+    """Return a MongoDB connection using environment settings."""
+    from pymongo import MongoClient  # Imported locally to avoid hard dependency
+
+    uri = os.environ.get("MONGO_URI", "mongodb://localhost:27017")
+    db_name = os.environ.get("MONGO_DB_NAME", "android_ms11")
+    client = MongoClient(uri)
+    return client[db_name]


### PR DESCRIPTION
## Summary
- extend `quest_selector` with map-based and DB-based loaders
- provide Mongo DB connection helper
- implement `cli/main.py` for selecting random quests by mode
- add tests for the new CLI

## Testing
- `pytest tests/test_random_quest_cli.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_b_685a15f0ecf8833188f2d0ab784e90b3