### PR TITLE
Add OCR-style dialogue choice selection

### DIFF
--- a/src/execution/dialogue.py
+++ b/src/execution/dialogue.py
@@ -1,12 +1,19 @@
+import random
+import time
+
+
 def execute_dialogue(step: dict) -> None:
     """Handle dialogue steps.
 
     This stub prints the NPC being interacted with and any dialogue options
-    provided in the quest data.
+    provided in the quest data. When options are present, a short delay is
+    simulated (as if reading text via OCR) and an option is selected either at
+    random or via an explicit ``selected_index`` field.
     """
 
     npc = step.get("npc", "Unknown NPC")
     options = step.get("options", [])
+    selected_index = step.get("selected_index")
 
     print(f"\U0001F5E8\uFE0F [Dialogue] Interacting with {npc}")
 
@@ -15,10 +22,13 @@ def execute_dialogue(step: dict) -> None:
         for i, opt in enumerate(options, 1):
             print(f"  {i}. {opt}")
 
-        # Simulate user choice — pick the first option for now
-        selected_index = 0
-        selected_option = options[selected_index]
+        # Simulate delay (e.g. OCR processing or UI wait time)
+        time.sleep(0.5)
 
+        if selected_index is None:
+            selected_index = random.randint(0, len(options) - 1)
+
+        selected_option = options[selected_index]
         print(f"\n\u27A1 You selected: '{selected_option}'")
     else:
         print("\U0001F4AC No dialogue options provided.")

--- a/tests/test_dialogue.py
+++ b/tests/test_dialogue.py
@@ -1,20 +1,43 @@
 import os
 import sys
+import random
+import time
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from src.execution.dialogue import execute_dialogue
 
 
-def test_execute_dialogue_logs_expected(capsys):
+def test_execute_dialogue_no_options(capsys):
+    step = {"npc": "Merchant"}
+    execute_dialogue(step)
+    captured = capsys.readouterr()
+    assert "[Dialogue] Interacting with Merchant" in captured.out
+    assert "No dialogue options provided." in captured.out
+
+
+def test_execute_dialogue_random_selection(monkeypatch, capsys):
     step = {
-        "type": "dialogue",
         "npc": "Lieutenant Serk",
         "options": ["Who are you?", "Where am I?", "Goodbye."],
     }
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+    monkeypatch.setattr(random, "randint", lambda a, b: 1)
     execute_dialogue(step)
     captured = capsys.readouterr()
-    assert "[Dialogue] Interacting with Lieutenant Serk" in captured.out
     assert "1. Who are you?" in captured.out
     assert "2. Where am I?" in captured.out
     assert "3. Goodbye." in captured.out
-    assert "You selected: 'Who are you?'" in captured.out
+    assert "You selected: 'Where am I?'" in captured.out
+
+
+def test_execute_dialogue_selected_index(monkeypatch, capsys):
+    step = {
+        "npc": "Guard",
+        "options": ["Hello", "Bye"],
+        "selected_index": 1,
+    }
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+    execute_dialogue(step)
+    captured = capsys.readouterr()
+    assert "You selected: 'Bye'" in captured.out


### PR DESCRIPTION
## Summary
- support OCR-style interaction by sleeping briefly and randomly selecting options
- allow overriding with `selected_index`
- expand dialogue tests with random selection and manual override cases

## Testing
- `pytest tests/test_dialogue.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a3f19fac48331ac0980db6901346a