### PR TITLE
Add execute_step dispatcher

### DIFF
--- a/src/execution/core.py
+++ b/src/execution/core.py
@@ -1,0 +1,12 @@
+"""Core step execution dispatcher."""
+
+from .dialogue import execute_dialogue
+
+
+def execute_step(step: dict) -> None:
+    """Dispatch a single step based on its ``type``."""
+    step_type = step.get("type")
+    if step_type == "dialogue":
+        execute_dialogue(step)
+    else:
+        print(f"[TODO] Unsupported step type: {step_type}")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.execution.core import execute_step
+
+
+def test_execute_step_dialogue(capsys):
+    step = {"type": "dialogue", "npc": "Trainer"}
+    execute_step(step)
+    captured = capsys.readouterr()
+    assert "Interacting with Trainer" in captured.out
+
+
+def test_execute_step_unknown(capsys):
+    step = {"type": "dance"}
+    execute_step(step)
+    captured = capsys.readouterr()
+    assert "[TODO] Unsupported step type: dance" in captured.out


### PR DESCRIPTION
## Summary
- implement `execute_step` dispatcher in `src/execution/core.py`
- add tests covering dialogue and unknown step types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a40e7e9fc83319751bde4a1776983