### PR TITLE
Add quest executor loop

### DIFF
--- a/src/execution/__init__.py
+++ b/src/execution/__init__.py
@@ -1,1 +1,6 @@
+"""Helpers for executing quest steps."""
 
+from .core import execute_step
+from .quest_executor import QuestExecutor
+
+__all__ = ["execute_step", "QuestExecutor"]

--- a/src/execution/quest_executor.py
+++ b/src/execution/quest_executor.py
@@ -1,0 +1,35 @@
+"""Real-time quest executor loop.
+
+This module loads a quest from a JSON file and iteratively processes each step
+using ``execute_step``. A short delay is included between steps to emulate
+in-game actions.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from .core import execute_step
+
+
+class QuestExecutor:
+    """Execute quest steps sequentially."""
+
+    def __init__(self, quest_path: str) -> None:
+        self.quest_path = quest_path
+        self.steps = self.load_steps()
+
+    def load_steps(self) -> list[dict]:
+        """Load quest step dictionaries from ``quest_path``."""
+        with open(self.quest_path, "r") as file:
+            return json.load(file)
+
+    def run(self) -> None:
+        """Run the quest, executing each step in order."""
+        print("[QUEST EXECUTOR] Starting quest sequence...")
+        for i, step in enumerate(self.steps, start=1):
+            print(f"[QUEST EXECUTOR] Executing step {i}: {step}")
+            execute_step(step)
+            time.sleep(1)  # simulate delay between steps
+

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.execution.quest_executor import QuestExecutor
+
+
+def test_executor_runs_sample_quest(tmp_path):
+    sample_quest = [
+        {"type": "quest", "id": "intro", "action": "start"},
+        {"type": "move", "to": {"planet": "Tatooine", "city": "Mos Eisley"}},
+        {"type": "dialogue", "npc": "Trainer"},
+    ]
+    quest_file = tmp_path / "sample_quest.json"
+    quest_file.write_text(json.dumps(sample_quest))
+
+    executor = QuestExecutor(str(quest_file))
+    executor.run()


### PR DESCRIPTION
## Summary
- add QuestExecutor to load quest JSON and run step-by-step using `execute_step`
- export `QuestExecutor` from execution package
- test quest executor with a sample quest

## Testing
- `pytest tests/test_executor.py::test_executor_runs_sample_quest -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a47789dc48331aa45e8680128e5c1