### PR TITLE
Add screen OCR utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ pytest==7.4.0
 beautifulsoup4==4.12.3
 playwright==1.42.0
 requests>=2.0
+
+pytesseract
+opencv-python
+pyautogui

--- a/src/vision/__init__.py
+++ b/src/vision/__init__.py
@@ -1,0 +1,3 @@
+from .ocr import screen_text, capture_screen, extract_text
+
+__all__ = ["screen_text", "capture_screen", "extract_text"]

--- a/src/vision/ocr.py
+++ b/src/vision/ocr.py
@@ -1,0 +1,21 @@
+import pytesseract
+import cv2
+import numpy as np
+import pyautogui
+
+
+def capture_screen(region=None) -> np.ndarray:
+    """Capture the screen or region as an OpenCV image."""
+    screenshot = pyautogui.screenshot(region=region)
+    return cv2.cvtColor(np.array(screenshot), cv2.COLOR_RGB2BGR)
+
+
+def extract_text(image: np.ndarray) -> str:
+    """Extract text from ``image`` using Tesseract OCR."""
+    return pytesseract.image_to_string(image)
+
+
+def screen_text(region=None) -> str:
+    """Capture the screen and return OCR text."""
+    img = capture_screen(region)
+    return extract_text(img)

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import types
+from PIL import Image
+import pytesseract
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a dummy pyautogui module for headless testing
+sys.modules['pyautogui'] = types.SimpleNamespace(
+    screenshot=lambda *a, **k: Image.new("RGB", (100, 100), color="white")
+)
+
+from src.vision.ocr import screen_text
+
+
+def test_screen_text_capture(monkeypatch):
+    monkeypatch.setattr(pytesseract, "image_to_string", lambda img: "dummy text")
+    text = screen_text()
+    assert isinstance(text, str)
+    print("[OCR TEST] Detected text sample:", text[:200])


### PR DESCRIPTION
## Summary
- add lightweight OCR helper module under `src/vision`
- expose OCR utilities
- add unit test using dummy screenshot
- install pytesseract, opencv-python, and pyautogui

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a48f885408331bb6f1b06f99f80c2