### PR TITLE
Add OCR feedback tests

### DIFF
--- a/tests/test_run_validated_step_with_ocr.py
+++ b/tests/test_run_validated_step_with_ocr.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import time
+from types import ModuleType
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.engine.step_executor import run_validated_step
+from src.engine.quest_executor import run_step_with_feedback
+
+
+def test_run_validated_step_ocr_success(monkeypatch):
+    fake_mod = ModuleType("src.vision.ocr")
+    fake_mod.screen_text = lambda *a, **k: "mission success"
+    monkeypatch.setitem(sys.modules, "src.vision.ocr", fake_mod)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    executed = []
+
+    def step():
+        executed.append(True)
+
+    assert run_validated_step(step, ["mission"], max_retries=1) is True
+    assert len(executed) == 1
+
+
+def test_run_validated_step_ocr_failure(monkeypatch):
+    fake_mod = ModuleType("src.vision.ocr")
+    fake_mod.screen_text = lambda *a, **k: "no match"
+    monkeypatch.setitem(sys.modules, "src.vision.ocr", fake_mod)
+    times = iter(range(100))
+    monkeypatch.setattr(time, "time", lambda: next(times))
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    executed = []
+
+    def step():
+        executed.append(True)
+
+    assert run_validated_step(step, ["expected"], max_retries=2) is False
+    assert len(executed) == 2
+
+
+def test_run_step_with_feedback_success(monkeypatch):
+    fake_mod = ModuleType("src.vision.ocr")
+    fake_mod.screen_text = lambda *a, **k: "intro mission started"
+    monkeypatch.setitem(sys.modules, "src.vision.ocr", fake_mod)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    executed = []
+    monkeypatch.setattr("src.engine.quest_executor.execute_step", lambda s: executed.append(s))
+    step = {"type": "quest", "action": "start", "success_texts": ["mission started"]}
+    assert run_step_with_feedback(step) is True
+    assert executed == [step]
+
+
+def test_run_step_with_feedback_abort(monkeypatch):
+    fake_mod = ModuleType("src.vision.ocr")
+    fake_mod.screen_text = lambda *a, **k: "irrelevant"
+    monkeypatch.setitem(sys.modules, "src.vision.ocr", fake_mod)
+    times = iter(range(100))
+    monkeypatch.setattr(time, "time", lambda: next(times))
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    executed = []
+    monkeypatch.setattr("src.engine.quest_executor.execute_step", lambda s: executed.append(s))
+    step = {"type": "quest", "action": "start", "success_texts": ["mission started"]}
+    assert run_step_with_feedback(step) is False
+    assert len(executed) == 3
+


### PR DESCRIPTION
## Summary
- create tests for `run_validated_step` success and failure scenarios
- ensure quests using `success_texts` work with mocked OCR output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a4e7a9b0483319ef49872ba320410