### PR TITLE
Add OCR-based StateManager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytesseract
 opencv-python
 pyautogui
 Pillow
+numpy

--- a/src/execution/__init__.py
+++ b/src/execution/__init__.py
@@ -2,4 +2,11 @@
 
 from .core import execute_step
 
-__all__ = ["execute_step"]
+__all__ = ["execute_step", "StateManager"]
+
+
+def __getattr__(name: str):
+    if name == "StateManager":
+        from .state_manager import StateManager as _StateManager
+        return _StateManager
+    raise AttributeError(name)

--- a/src/execution/state_manager.py
+++ b/src/execution/state_manager.py
@@ -1,0 +1,43 @@
+"""Simple state monitoring via OCR."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Mapping, MutableMapping
+
+from src.vision import ocr
+
+
+class StateManager:
+    """Monitor on-screen text and trigger callbacks when keywords appear."""
+
+    def __init__(
+        self,
+        callbacks: Mapping[str, Callable[[], None]],
+        *,
+        region=None,
+        interval: float = 1.0,
+    ) -> None:
+        self.callbacks: MutableMapping[str, Callable[[], None]] = dict(callbacks)
+        self.region = region
+        self.interval = interval
+        self._running = False
+
+    def _check_once(self) -> None:
+        image = ocr.capture_screen(region=self.region)
+        text = ocr.extract_text(image).lower()
+        for key, cb in list(self.callbacks.items()):
+            if key.lower() in text:
+                cb()
+
+    def run(self, duration: float | None = None) -> None:
+        """Run the monitoring loop optionally for ``duration`` seconds."""
+        self._running = True
+        end_time = time.time() + duration if duration is not None else None
+        while self._running and (end_time is None or time.time() < end_time):
+            self._check_once()
+            time.sleep(max(self.interval, 0))
+
+    def stop(self) -> None:
+        """Stop the monitoring loop."""
+        self._running = False

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import time
+from types import ModuleType
+
+# Provide fake OCR module before importing StateManager
+fake_ocr = ModuleType("src.vision.ocr")
+texts = iter(["ignore", "quest accepted"])
+fake_ocr.capture_screen = lambda *a, **k: None
+fake_ocr.extract_text = lambda img: next(texts)
+fake_ocr.screen_text = lambda *a, **k: next(texts)
+sys.modules["src.vision.ocr"] = fake_ocr
+if "src.vision" in sys.modules:
+    sys.modules["src.vision"].ocr = fake_ocr
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.execution.state_manager import StateManager
+
+
+def test_state_manager_callbacks(monkeypatch):
+    times = iter([0, 0, 0.5, 1.5])
+    monkeypatch.setattr(time, "time", lambda: next(times))
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+
+    triggered = []
+
+    def on_quest():
+        triggered.append("quest")
+
+    manager = StateManager({"quest": on_quest}, interval=0)
+    manager.run(duration=1)
+
+    assert triggered == ["quest"]


### PR DESCRIPTION
## Summary
- implement `StateManager` for monitoring screen text via OCR
- expose `StateManager` lazily from `src.execution`
- include `numpy` dependency for OCR helpers
- test callbacks triggered when OCR text matches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685acfeaea448331b9c3ab67fc712bc4