### PR TITLE
Add state manager module with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,15 @@ if verify_source(quest):
 
 ## Monitoring On-Screen Events
 
-`src/execution/state_manager.py` contains `StateManager`, a helper that watches
-OCR text and triggers callbacks when phrases appear. Register your conditions in
-a dictionary and run the monitor to react to game state.
+`src/state/state_manager.py` provides a `StateManager` for general game state
+tracking. It watches OCR text and triggers callbacks when phrases appear,
+updating ``current_state`` to the matched key. Modules under
+`src/execution` still expose a lightweight version for internal helpers. Use
+the state module when you want to react to global game conditions and the
+execution module when writing step-by-step automation.
 
 ```python
-from src.execution.state_manager import StateManager
+from src.state.state_manager import StateManager
 
 def on_accept():
     print("Quest accepted!")

--- a/main_state_runner.py
+++ b/main_state_runner.py
@@ -1,0 +1,25 @@
+"""Example script demonstrating the ``StateManager``."""
+
+from src.state import StateManager
+
+
+def on_mission_board():
+    print("Mission Board detected")
+
+
+def on_quest_completed():
+    print("Quest completed!")
+
+
+def on_error():
+    print("Error detected!")
+
+
+if __name__ == "__main__":
+    callbacks = {
+        "mission board": on_mission_board,
+        "quest completed": on_quest_completed,
+        "error": on_error,
+    }
+    manager = StateManager(callbacks, interval=0.5)
+    manager.run(duration=10)

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -1,0 +1,10 @@
+"""Game state helpers."""
+
+__all__ = ["StateManager"]
+
+
+def __getattr__(name: str):
+    if name == "StateManager":
+        from .state_manager import StateManager as _StateManager
+        return _StateManager
+    raise AttributeError(name)

--- a/src/state/state_manager.py
+++ b/src/state/state_manager.py
@@ -1,0 +1,49 @@
+"""State manager that monitors on-screen text."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Mapping, MutableMapping
+
+from src.vision import ocr
+
+
+class StateManager:
+    """Monitor on-screen text and trigger callbacks when phrases appear.
+
+    The key for each callback also represents the current state when that
+    phrase is detected.
+    """
+
+    def __init__(
+        self,
+        callbacks: Mapping[str, Callable[[], None]],
+        *,
+        region=None,
+        interval: float = 1.0,
+    ) -> None:
+        self.callbacks: MutableMapping[str, Callable[[], None]] = dict(callbacks)
+        self.region = region
+        self.interval = interval
+        self.current_state: str | None = None
+        self._running = False
+
+    def _check_once(self) -> None:
+        image = ocr.capture_screen(region=self.region)
+        text = ocr.extract_text(image).lower()
+        for key, cb in list(self.callbacks.items()):
+            if key.lower() in text:
+                self.current_state = key
+                cb()
+
+    def run(self, duration: float | None = None) -> None:
+        """Run the monitoring loop optionally for ``duration`` seconds."""
+        self._running = True
+        end_time = time.time() + duration if duration is not None else None
+        while self._running and (end_time is None or time.time() < end_time):
+            self._check_once()
+            time.sleep(max(self.interval, 0))
+
+    def stop(self) -> None:
+        """Stop the monitoring loop."""
+        self._running = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import sys
+import types
+
+# Provide stub modules for optional dependencies
+if 'pytesseract' not in sys.modules:
+    sys.modules['pytesseract'] = types.SimpleNamespace(image_to_string=lambda *a, **k: '')
+
+if 'PIL' not in sys.modules:
+    pil_module = types.ModuleType('PIL')
+    pil_image = types.SimpleNamespace(new=lambda *a, **k: object())
+    pil_module.Image = pil_image
+    sys.modules['PIL'] = pil_module
+    sys.modules['PIL.Image'] = pil_image
+
+sys.modules.setdefault('cv2', types.SimpleNamespace(COLOR_RGB2BGR=None, cvtColor=lambda img, flag: img))
+
+if 'numpy' not in sys.modules:
+    np_module = types.ModuleType('numpy')
+    np_module.array = lambda x: x
+    np_module.ndarray = object
+    sys.modules['numpy'] = np_module
+
+sys.modules.setdefault('pyautogui', types.SimpleNamespace(screenshot=lambda *a, **k: sys.modules['PIL.Image'].new('RGB', (1, 1))))

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -15,7 +15,7 @@ sys.modules["src.vision.ocr"] = fake_ocr
 if "src.vision" in sys.modules:
     sys.modules["src.vision"].ocr = fake_ocr
 
-from src.execution.state_manager import StateManager
+from src.state.state_manager import StateManager
 
 
 def test_state_manager_callbacks(monkeypatch):
@@ -32,3 +32,4 @@ def test_state_manager_callbacks(monkeypatch):
     manager.run(duration=1)
 
     assert triggered == ["quest"]
+    assert manager.current_state == "quest"


### PR DESCRIPTION
## Summary
- implement `StateManager` in `src/state` and expose via `__getattr__`
- provide example runner `main_state_runner.py`
- update README to document state manager usage and new import path
- update tests to use new state manager location
- add `tests/conftest.py` with stubs for optional packages

## Testing
- `python -m pytest tests/test_state_manager.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ad7ab13a88331a7cbc115fa44649e