### PR TITLE
Improve logging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,11 @@ You can further control the selection with these options:
 - `--debug` &ndash; show the full quest data instead of a summary.
 
 Every run appends the chosen quest to `logs/quest_selections.log`.
+
+## Log Files
+The application writes several logs under the `logs/` directory:
+
+- `logs/app.log` &ndash; general runtime messages produced by `start_log()`.
+- `logs/quest_selections.log` &ndash; history of quests chosen via the CLI.
+- `logs/step_journal.log` &ndash; success/failure records from step validation.
+- `logs/session_*.log` &ndash; detailed step traces for each session.

--- a/src/log_manager.py
+++ b/src/log_manager.py
@@ -1,5 +1,25 @@
 """Manage log output for Android MS11."""
 
-def start_log():
-    """Placeholder to initialize logging."""
-    print("Log started.")
+from __future__ import annotations
+
+import logging
+import os
+
+
+DEFAULT_LOG_PATH = os.path.join("logs", "app.log")
+
+
+def start_log(log_path: str = DEFAULT_LOG_PATH) -> logging.Logger:
+    """Configure basic logging to ``log_path`` and return the logger."""
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.FileHandler(log_path, encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+    )
+    logger = logging.getLogger("ms11")
+    logger.info("Log started.")
+    return logger

--- a/src/logger_utils.py
+++ b/src/logger_utils.py
@@ -2,7 +2,7 @@
 import os
 from typing import List
 
-DEFAULT_LOG_PATH = "ams11.log"
+DEFAULT_LOG_PATH = os.path.join("logs", "ams11.log")
 
 def read_logs(path: str = DEFAULT_LOG_PATH, num_lines: int = 5) -> List[str]:
     """Return the last ``num_lines`` lines from ``path``.

--- a/tests/test_log_manager.py
+++ b/tests/test_log_manager.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.log_manager import start_log
+
+
+def test_start_log_creates_file(tmp_path, monkeypatch):
+    log_file = tmp_path / "test.log"
+    start_log(log_path=str(log_file))
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- implement real logging in `src/log_manager.py`
- store default log file in `logs/app.log`
- move `DEFAULT_LOG_PATH` for debug logs to `logs/ams11.log`
- document all log paths in README
- add regression test for the new logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ada94abb8833188f870a83e90a5ad