### PR TITLE
Add mode-aware automator loop

### DIFF
--- a/src/automation/automator.py
+++ b/src/automation/automator.py
@@ -3,21 +3,47 @@ import time
 from src.vision.ocr import capture_screen, extract_text
 from src.vision.states import detect_state, handle_state
 from src.utils.logger import save_screenshot, log_ocr_text
+from . import mode_manager
 
 
-def run_state_monitor_loop(delay: float = 2.0):
+def _questing_behavior() -> None:
+    """Default questing loop behavior."""
+    image = capture_screen()
+    text = extract_text(image)
+    state = detect_state(text)
+
+    if state:
+        print(f"[MATCHED STATE] {state}")
+        save_screenshot(image)
+        log_ocr_text(text)
+        handle_state(state)
+    else:
+        print("[NO MATCH] Continuing scan...")
+
+
+def _combat_behavior() -> None:
+    """Placeholder combat mode behavior."""
+    print("[COMBAT] Engaging enemies...")
+
+
+def _vendor_behavior() -> None:
+    """Placeholder vendor mode behavior."""
+    print("[VENDOR] Checking vendor inventory...")
+
+
+MODE_BEHAVIORS = {
+    "questing": _questing_behavior,
+    "combat": _combat_behavior,
+    "vendor": _vendor_behavior,
+}
+
+
+def run_state_monitor_loop(delay: float = 2.0, iterations: int | None = None) -> None:
+    """Run the state monitor loop for ``iterations`` cycles or indefinitely."""
     print("[AUTOMATOR] Starting screen state detection loop.")
-    while True:
-        image = capture_screen()
-        text = extract_text(image)
-        state = detect_state(text)
-
-        if state:
-            print(f"[MATCHED STATE] {state}")
-            save_screenshot(image)
-            log_ocr_text(text)
-            handle_state(state)
-        else:
-            print("[NO MATCH] Continuing scan...")
-
+    count = 0
+    while iterations is None or count < iterations:
+        behavior = MODE_BEHAVIORS.get(mode_manager.current_mode, _questing_behavior)
+        behavior()
+        count += 1
         time.sleep(delay)

--- a/src/automation/mode_manager.py
+++ b/src/automation/mode_manager.py
@@ -1,0 +1,13 @@
+"""Simple mode manager for the automator."""
+
+VALID_MODES = ("questing", "combat", "vendor")
+
+current_mode: str = "questing"
+
+
+def set_mode(mode: str) -> None:
+    """Update :data:`current_mode` if ``mode`` is valid."""
+    if mode not in VALID_MODES:
+        raise ValueError(f"Invalid mode: {mode}")
+    global current_mode
+    current_mode = mode

--- a/tests/test_automator_modes.py
+++ b/tests/test_automator_modes.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.automation import automator
+from src.automation import mode_manager
+
+
+def test_set_mode_updates_current_mode():
+    mode_manager.set_mode("combat")
+    assert mode_manager.current_mode == "combat"
+    with pytest.raises(ValueError):
+        mode_manager.set_mode("invalid")
+
+
+def test_run_state_monitor_loop_uses_selected_mode(monkeypatch):
+    calls = []
+
+    def combat_behavior():
+        calls.append("combat")
+
+    monkeypatch.setattr(automator, "MODE_BEHAVIORS", {"combat": combat_behavior})
+    mode_manager.set_mode("combat")
+    monkeypatch.setattr(automator.time, "sleep", lambda *_: None)
+    automator.run_state_monitor_loop(delay=0, iterations=1)
+    assert calls == ["combat"]


### PR DESCRIPTION
## Summary
- add `mode_manager` with `current_mode` and a helper for switching modes
- branch automator loop by `mode_manager.current_mode`
- provide dummy combat and vendor behaviors
- test that modes can be changed and the automator dispatches correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ae9238c888331ac09e3d520fa5d0a