### PR TITLE
Add mode runner for multiple automation modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ This section walks through a fresh setup so you can try the project locally.
 These steps should give you a working copy of Android MS11 and confidence
 that the provided modules function as expected.
 
+## Automation Modes
+Select a runtime mode when starting the automation. The ``--mode`` option
+controls which behavior module is activated.
+
+```bash
+python src/main.py --mode questing
+python src/main.py --mode medic
+python src/main.py --mode grinding
+```
+
 ## Legacy Quest Manager CLI
 Use the legacy quest tool to explore old mission data.
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
+import argparse
+
 from src.vision.states import register_state
-from src.automation.automator import run_state_monitor_loop
+from src.modes.mode_runner import run_mode
 
 
-def setup_known_states():
+def setup_known_states() -> None:
     register_state("continue_prompt", ["press enter to continue"])
     register_state(
         "npc_dialogue",
@@ -10,6 +12,14 @@ def setup_known_states():
     )
 
 
-if __name__ == "__main__":
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True, help="Mode to run (questing, medic, etc.)")
+    args = parser.parse_args()
+
     setup_known_states()
-    run_state_monitor_loop()
+    run_mode(args.mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/modes/grinding.py
+++ b/src/modes/grinding.py
@@ -1,0 +1,7 @@
+from src.automation.automator import run_state_monitor_loop
+
+
+def start() -> None:
+    """Entry point for grinding mode."""
+    print("[MODE] Grinding mode started")
+    run_state_monitor_loop()

--- a/src/modes/medic.py
+++ b/src/modes/medic.py
@@ -1,0 +1,7 @@
+from src.automation.automator import run_state_monitor_loop
+
+
+def start() -> None:
+    """Entry point for medic mode."""
+    print("[MODE] Medic mode started")
+    run_state_monitor_loop()

--- a/src/modes/mode_runner.py
+++ b/src/modes/mode_runner.py
@@ -1,0 +1,13 @@
+from src.modes import questing, medic, grinding
+
+
+def run_mode(mode_name: str) -> None:
+    """Dispatch to the requested automation mode."""
+    if mode_name == "questing":
+        questing.start()
+    elif mode_name == "medic":
+        medic.start()
+    elif mode_name == "grinding":
+        grinding.start()
+    else:
+        print(f"[MODE] Unknown mode '{mode_name}'")

--- a/src/modes/questing.py
+++ b/src/modes/questing.py
@@ -1,0 +1,7 @@
+from src.automation.automator import run_state_monitor_loop
+
+
+def start() -> None:
+    """Entry point for questing mode."""
+    print("[MODE] Questing mode started")
+    run_state_monitor_loop()


### PR DESCRIPTION
## Summary
- add new `modes` package with questing, medic and grinding placeholders
- implement `mode_runner.run_mode` dispatcher
- update `main.py` to accept `--mode` argument and use the dispatcher
- document available automation modes in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685af4b63da4833197b9e7d97ce66047