### PR TITLE
Implement movement profiles and integrate with main

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 from core.session_manager import SessionManager
 from src.movement.agent_mover import MovementAgent
+from src.movement.movement_profiles import travel_to_city
 
 
 def main():
@@ -13,10 +14,8 @@ def main():
     session.set_end_credits(2300)
 
     # Movement Test
-    agent = MovementAgent(
-        session=session, current_location="Theed", destination="Mos Eisley"
-    )
-    agent.move_to()
+    agent = MovementAgent(session=session)
+    travel_to_city(agent, "Anchorhead")
 
     # End session and save log
     session.end_session()

--- a/src/movement/movement_profiles.py
+++ b/src/movement/movement_profiles.py
@@ -1,0 +1,21 @@
+"""Strategy functions for common movement behaviors."""
+
+from .agent_mover import MovementAgent
+
+
+def travel_to_city(agent: MovementAgent, destination: str) -> None:
+    """Move the agent directly to the given destination."""
+    agent.destination = destination
+    agent.move_to()
+
+
+def patrol_route(agent: MovementAgent, route) -> None:
+    """Patrol through each stop in the provided route."""
+    for stop in route:
+        agent.destination = stop
+        agent.move_to()
+
+
+def idle(agent: MovementAgent) -> None:
+    """Perform no movement."""
+    agent.session.add_action("Staying idle, no movement performed.")


### PR DESCRIPTION
## Summary
- add strategy functions for common movement profiles
- call `travel_to_city` from `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b028f2e008331a9d518226dccf120