### PR TITLE
Add waypoint patrol system

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 from core.session_manager import SessionManager
 from src.movement.agent_mover import MovementAgent
-from src.movement.movement_profiles import travel_to_city
+from src.movement.movement_profiles import patrol_route
 
 
 def main():
@@ -15,7 +15,7 @@ def main():
 
     # Movement Test
     agent = MovementAgent(session=session)
-    travel_to_city(agent, "Anchorhead")
+    patrol_route(agent, "Anchorhead-Loop")
 
     # End session and save log
     session.end_session()

--- a/src/movement/movement_profiles.py
+++ b/src/movement/movement_profiles.py
@@ -1,6 +1,7 @@
 """Strategy functions for common movement behaviors."""
 
 from .agent_mover import MovementAgent
+from .waypoints import get_waypoint_route
 
 
 def travel_to_city(agent: MovementAgent, destination: str) -> None:
@@ -9,8 +10,13 @@ def travel_to_city(agent: MovementAgent, destination: str) -> None:
     agent.move_to()
 
 
-def patrol_route(agent: MovementAgent, route) -> None:
-    """Patrol through each stop in the provided route."""
+def patrol_route(agent: MovementAgent, route_name: str) -> None:
+    """Patrol through the stops in the named waypoint route."""
+    route = get_waypoint_route(route_name)
+    if not route:
+        agent.session.add_action(f"Route '{route_name}' not found.")
+        return
+
     for stop in route:
         agent.destination = stop
         agent.move_to()

--- a/src/movement/waypoints.py
+++ b/src/movement/waypoints.py
@@ -1,0 +1,12 @@
+"""Waypoint utilities for movement routes."""
+
+WAYPOINTS = {
+    "Anchorhead-Loop": ["Anchorhead", "Wayfar", "Bestine", "Anchorhead"],
+    "Theed-Bounce": ["Theed", "Moenia", "Theed"],
+}
+
+
+def get_waypoint_route(name: str):
+    """Return the waypoint route list for ``name``."""
+    return WAYPOINTS.get(name, [])
+

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -11,3 +11,36 @@ def test_execute_movement_prints_destination(capsys):
     execute_movement(step)
     captured = capsys.readouterr()
     assert captured.out.strip() == "Moving to Tatooine, Mos Eisley"
+
+
+class DummySession:
+    def __init__(self):
+        self.actions = []
+
+    def add_action(self, action):
+        self.actions.append(action)
+
+
+def test_patrol_route_loops(capsys):
+    from src.movement.agent_mover import MovementAgent
+    from src.movement.movement_profiles import patrol_route
+
+    session = DummySession()
+    agent = MovementAgent(session=session)
+    patrol_route(agent, "Anchorhead-Loop")
+
+    captured = capsys.readouterr()
+    output_lines = [line for line in captured.out.splitlines() if line.startswith("Moving")] 
+    assert len(output_lines) == 4
+    assert output_lines[0] == "Moving from Theed to Anchorhead"
+
+
+def test_patrol_route_missing_route():
+    from src.movement.agent_mover import MovementAgent
+    from src.movement.movement_profiles import patrol_route
+
+    session = DummySession()
+    agent = MovementAgent(session=session)
+    patrol_route(agent, "Nowhere")
+
+    assert session.actions[-1] == "Route 'Nowhere' not found."


### PR DESCRIPTION
## Summary
- implement waypoint utilities with named routes
- expand patrol_route to use named waypoint routes
- update main demo to patrol an Anchorhead loop
- add tests for patrol_route behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b04a0a90c8331ae41a3b556d2b986