### PR TITLE
Implement patrol wait times

### DIFF
--- a/src/movement/movement_profiles.py
+++ b/src/movement/movement_profiles.py
@@ -2,6 +2,8 @@
 
 from .agent_mover import MovementAgent
 from .waypoints import get_waypoint_route
+import time
+import random
 
 
 def travel_to_city(agent: MovementAgent, destination: str) -> None:
@@ -20,6 +22,13 @@ def patrol_route(agent: MovementAgent, route_name: str) -> None:
     for stop in route:
         agent.destination = stop
         agent.move_to()
+
+        # Simulate human-like pause between moves
+        wait_time = random.uniform(5.0, 15.0)
+        agent.session.add_action(
+            f"Waiting {wait_time:.1f} seconds before next move."
+        )
+        time.sleep(wait_time)
 
 
 def idle(agent: MovementAgent) -> None:

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.execution.movement import execute_movement
+from unittest.mock import patch
 
 
 def test_execute_movement_prints_destination(capsys):
@@ -21,7 +22,8 @@ class DummySession:
         self.actions.append(action)
 
 
-def test_patrol_route_loops(capsys):
+@patch("src.movement.movement_profiles.time.sleep", return_value=None)
+def test_patrol_route_with_waits(mock_sleep, capsys):
     from src.movement.agent_mover import MovementAgent
     from src.movement.movement_profiles import patrol_route
 
@@ -30,9 +32,12 @@ def test_patrol_route_loops(capsys):
     patrol_route(agent, "Anchorhead-Loop")
 
     captured = capsys.readouterr()
-    output_lines = [line for line in captured.out.splitlines() if line.startswith("Moving")] 
+    output_lines = [line for line in captured.out.splitlines() if line.startswith("Moving")]
     assert len(output_lines) == 4
     assert output_lines[0] == "Moving from Theed to Anchorhead"
+    assert mock_sleep.call_count == 4
+    waiting_actions = [a for a in session.actions if str(a).startswith("Waiting ")]
+    assert len(waiting_actions) == 4
 
 
 def test_patrol_route_missing_route():


### PR DESCRIPTION
## Summary
- simulate more realistic travel by pausing between patrol stops
- log wait actions to the session log
- update movement tests to patch `time.sleep`

## Testing
- `pytest -q`
- `pytest -q tests/test_movement.py::test_patrol_route_with_waits -q`

------
https://chatgpt.com/codex/tasks/task_b_685b06681a608331a19ee2326f908277