### PR TITLE
Implement trainer visit feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In the world of **Argent**, legendary guilds compete to recover ancient relics. 
 
 ## Basic Usage
 Install the dependencies and then import the modules you need.
-The `requirements.txt` file now includes `requests>=2.0`:
+The `requirements.txt` file now includes `requests>=2.0` and `PyYAML`:
 ```bash
 pip install -r requirements.txt
 ```
@@ -93,7 +93,7 @@ This section walks through a fresh setup so you can try the project locally.
    ```bash
    pip install -r requirements.txt
    ```
-   The requirements file includes `requests>=2.0`.
+    The requirements file includes `requests>=2.0` and `PyYAML`.
 
 4. **Run the example application**
 
@@ -118,7 +118,7 @@ This section walks through a fresh setup so you can try the project locally.
    ```bash
    pip install -r requirements.txt
    pytest
-   # includes requests>=2.0
+    # includes requests>=2.0 and PyYAML
    ```
 
 These steps should give you a working copy of Android MS11 and confidence

--- a/data/trainers.yaml
+++ b/data/trainers.yaml
@@ -1,0 +1,18 @@
+artisan:
+  corellia:
+    coronet:
+      name: "Artisan Trainer"
+      x: -123
+      y: 44
+  tatooine:
+    mos_eisley:
+      name: "Artisan Trainer"
+      x: 3432
+      y: -4795
+
+marksman:
+  corellia:
+    coronet:
+      name: "Marksman Trainer"
+      x: -150
+      y: 60

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ beautifulsoup4==4.12.3
 playwright==1.42.0
 requests>=2.0
 
+PyYAML
+
 pytesseract
 opencv-python
 pyautogui

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from core.session_manager import SessionManager
 from src.movement.agent_mover import MovementAgent
 from src.movement.movement_profiles import patrol_route
+from src.training.trainer_visit import visit_trainer
 
 
 def main():
@@ -16,6 +17,9 @@ def main():
     # Movement Test
     agent = MovementAgent(session=session)
     patrol_route(agent, "Anchorhead-Loop")
+
+    # Try visiting artisan trainer
+    visit_trainer(agent, "artisan", planet="tatooine", city="mos_eisley")
 
     # End session and save log
     session.end_session()

--- a/src/training/trainer_data_loader.py
+++ b/src/training/trainer_data_loader.py
@@ -1,0 +1,18 @@
+import yaml
+from pathlib import Path
+
+TRAINER_FILE = Path(__file__).resolve().parent.parent.parent / "data" / "trainers.yaml"
+
+
+def load_trainer_data():
+    with open(TRAINER_FILE, "r") as file:
+        return yaml.safe_load(file)
+
+
+def get_trainer_coords(profession, planet, city):
+    data = load_trainer_data()
+    try:
+        trainer = data[profession][planet][city]
+        return (trainer['name'], trainer['x'], trainer['y'])
+    except KeyError:
+        return None

--- a/src/training/trainer_visit.py
+++ b/src/training/trainer_visit.py
@@ -1,0 +1,15 @@
+from .trainer_data_loader import get_trainer_coords
+from src.movement.movement_profiles import travel_to_city
+
+
+def visit_trainer(agent, profession, planet="tatooine", city="mos_eisley"):
+    trainer_info = get_trainer_coords(profession, planet, city)
+
+    if trainer_info:
+        name, x, y = trainer_info
+        print(f"[Trainer] Found static trainer data: {name} at ({x}, {y})")
+        travel_to_city(agent, city)
+        # Future: move to exact coordinates
+    else:
+        print("[Trainer] No static data. Will try /find or scan logic next.")
+        # Stub: implement /find fallback here

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,6 +4,16 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.automation.training import train_with_npc
+from src.training.trainer_data_loader import get_trainer_coords
+from src.training.trainer_visit import visit_trainer
+
+
+class DummyAgent:
+    def __init__(self):
+        self.destination = None
+
+    def move_to(self):
+        print(f"Moving to {self.destination}")
 
 
 def test_train_with_npc(capfd):
@@ -11,3 +21,31 @@ def test_train_with_npc(capfd):
     train_with_npc(step)
     out, _ = capfd.readouterr()
     assert "Learning new abilities from Trainer" in out
+
+
+def test_get_trainer_coords():
+    result = get_trainer_coords("artisan", "tatooine", "mos_eisley")
+    assert result == ("Artisan Trainer", 3432, -4795)
+
+
+def test_visit_trainer_found(monkeypatch, capsys):
+    agent = DummyAgent()
+
+    called = {}
+
+    def fake_travel(agent_obj, destination):
+        called["dest"] = destination
+
+    monkeypatch.setattr("src.training.trainer_visit.travel_to_city", fake_travel)
+    visit_trainer(agent, "artisan", planet="tatooine", city="mos_eisley")
+    out = capsys.readouterr().out
+    assert "Artisan Trainer" in out
+    assert called["dest"] == "mos_eisley"
+
+
+def test_visit_trainer_missing(monkeypatch, capsys):
+    agent = DummyAgent()
+    monkeypatch.setattr("src.training.trainer_visit.travel_to_city", lambda a, d: None)
+    visit_trainer(agent, "medic", planet="naboo", city="theed")
+    out = capsys.readouterr().out
+    assert "No static data" in out


### PR DESCRIPTION
## Summary
- add data for static trainers
- load trainer YAML and expose visit_trainer helper
- integrate example trainer visit in main
- document new PyYAML requirement
- test trainer loader and visit logic

## Testing
- `pip install PyYAML`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b0d57f5088331800569fc70f4c203