### PR TITLE
Handle missing trainer file gracefully

### DIFF
--- a/src/training/trainer_data_loader.py
+++ b/src/training/trainer_data_loader.py
@@ -1,12 +1,17 @@
 import yaml
 from pathlib import Path
+import logging
 
 TRAINER_FILE = Path(__file__).resolve().parent.parent.parent / "data" / "trainers.yaml"
 
 
 def load_trainer_data():
-    with open(TRAINER_FILE, "r") as file:
-        return yaml.safe_load(file)
+    try:
+        with open(TRAINER_FILE, "r") as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError:  # pragma: no cover - best effort logging
+        logging.warning(f"Trainer file {TRAINER_FILE} not found. Returning empty dict.")
+        return {}
 
 
 def get_trainer_coords(profession, planet, city):

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,7 +4,8 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.automation.training import train_with_npc
-from src.training.trainer_data_loader import get_trainer_coords
+from pathlib import Path
+from src.training.trainer_data_loader import get_trainer_coords, load_trainer_data
 from src.training.trainer_visit import visit_trainer
 
 
@@ -49,3 +50,10 @@ def test_visit_trainer_missing(monkeypatch, capsys):
     visit_trainer(agent, "medic", planet="naboo", city="theed")
     out = capsys.readouterr().out
     assert "No static data" in out
+
+
+def test_load_trainer_data_missing_file(monkeypatch):
+    missing = Path("nonexistent_file.yaml")
+    monkeypatch.setattr("src.training.trainer_data_loader.TRAINER_FILE", missing)
+    data = load_trainer_data()
+    assert data == {}


### PR DESCRIPTION
## Summary
- handle missing trainer data file in `load_trainer_data`
- simulate missing trainer file in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b0ff683ac83318486f2ac734c0160