### PR TITLE
Add coordinate movement helper and trainer update

### DIFF
--- a/src/movement/__init__.py
+++ b/src/movement/__init__.py
@@ -1,1 +1,5 @@
+"""Movement package exposing basic helpers."""
 
+from .coordinate_movement import move_to_coordinates
+
+__all__ = ["move_to_coordinates"]

--- a/src/movement/coordinate_movement.py
+++ b/src/movement/coordinate_movement.py
@@ -1,0 +1,15 @@
+"""Helpers for coordinate-based movement."""
+
+from .agent_mover import MovementAgent
+
+
+def move_to_coordinates(agent: MovementAgent, x: int, y: int) -> None:
+    """Move ``agent`` to the given ``x``/``y`` coordinates.
+
+    This function simply prints a message and records the action using the
+    agent's session. It does not attempt to simulate any game-specific
+    navigation logic.
+    """
+    action = f"Moving to coordinates ({x}, {y})"
+    print(action)
+    agent.session.add_action(action)

--- a/src/training/trainer_visit.py
+++ b/src/training/trainer_visit.py
@@ -1,5 +1,6 @@
 from .trainer_data_loader import get_trainer_coords
 from src.movement.movement_profiles import travel_to_city
+from src.movement.coordinate_movement import move_to_coordinates
 
 
 def visit_trainer(agent, profession, planet="tatooine", city="mos_eisley"):
@@ -9,7 +10,7 @@ def visit_trainer(agent, profession, planet="tatooine", city="mos_eisley"):
         name, x, y = trainer_info
         print(f"[Trainer] Found static trainer data: {name} at ({x}, {y})")
         travel_to_city(agent, city)
-        # Future: move to exact coordinates
+        move_to_coordinates(agent, x, y)
     else:
         print("[Trainer] No static data. Will try /find or scan logic next.")
         # Stub: implement /find fallback here

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -37,11 +37,19 @@ def test_visit_trainer_found(monkeypatch, capsys):
     def fake_travel(agent_obj, destination):
         called["dest"] = destination
 
+    def fake_coords(agent_obj, x, y):
+        called["coords"] = (x, y)
+
     monkeypatch.setattr("src.training.trainer_visit.travel_to_city", fake_travel)
+    monkeypatch.setattr(
+        "src.training.trainer_visit.move_to_coordinates",
+        fake_coords,
+    )
     visit_trainer(agent, "artisan", planet="tatooine", city="mos_eisley")
     out = capsys.readouterr().out
     assert "Artisan Trainer" in out
     assert called["dest"] == "mos_eisley"
+    assert called["coords"] == (3432, -4795)
 
 
 def test_visit_trainer_missing(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- introduce `move_to_coordinates` in movement helpers
- call coordinate movement after travelling to city when visiting a trainer
- extend trainer visit test to ensure coordinate movement

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685b10c1061c8331995c962ddb836ba3