### PR TITLE
Improve trainer search behavior

### DIFF
--- a/src/training/trainer_visit.py
+++ b/src/training/trainer_visit.py
@@ -1,6 +1,18 @@
 from .trainer_data_loader import get_trainer_coords
 from src.movement.movement_profiles import travel_to_city, walk_to_coords
 
+# Keep a simple in-memory log of NPCs we've attempted to visit.  This can be
+# inspected by other modules or unit tests for validation purposes.
+visited_npcs = []
+
+# Default fallback locations to search if the trainer is not immediately found.
+# These coordinates are intentionally generic and may be adjusted for specific
+# cities in the future.
+COMMON_LOCATIONS = [
+    ("mission terminal", (0, 0)),
+    ("cantina", (10, 10)),
+]
+
 
 def visit_trainer(agent, profession, planet="tatooine", city="mos_eisley"):
     trainer_info = get_trainer_coords(profession, planet, city)
@@ -12,6 +24,23 @@ def visit_trainer(agent, profession, planet="tatooine", city="mos_eisley"):
         )
         travel_to_city(agent, city)
         walk_to_coords(agent, x, y)
+        visited_npcs.append(name)
+        if getattr(agent, "session", None):
+            agent.session.add_action(f"Visited trainer {name}")
     else:
         print(f"[Trainer] Trainer not found for {profession} in {city}, {planet}.")
-        print("[Trainer] Attempting /find or fallback logic (not yet implemented)")
+        chat_cmd = f"/find {profession} trainer"
+        print("[Trainer] Attempting /find command...")
+        # Simulate sending the chat command through the agent if possible
+        if hasattr(agent, "send_chat"):
+            agent.send_chat(chat_cmd)
+        else:
+            print(f"[Chat] {chat_cmd}")
+
+        for location, (x, y) in COMMON_LOCATIONS:
+            print(f"[Trainer] Searching {location} at ({x}, {y})")
+            walk_to_coords(agent, x, y)
+
+        visited_npcs.append(f"{profession} trainer")
+        if getattr(agent, "session", None):
+            agent.session.add_action(f"Searched for {profession} trainer")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -53,11 +53,26 @@ def test_visit_trainer_found(monkeypatch, capsys):
 
 
 def test_visit_trainer_missing(monkeypatch, capsys):
+    from src.training import trainer_visit
+
     agent = DummyAgent()
+    walk_calls = []
+
     monkeypatch.setattr("src.training.trainer_visit.travel_to_city", lambda a, d: None)
+    monkeypatch.setattr(
+        "src.training.trainer_visit.walk_to_coords",
+        lambda a, x, y: walk_calls.append((x, y)),
+    )
+
+    trainer_visit.visited_npcs.clear()
+
     visit_trainer(agent, "medic", planet="naboo", city="theed")
     out = capsys.readouterr().out
     assert "Trainer not found" in out
+    assert "/find medic trainer" in out
+    assert (0, 0) in walk_calls
+    assert (10, 10) in walk_calls
+    assert "medic trainer" in trainer_visit.visited_npcs
 
 
 def test_load_trainer_data_missing_file(monkeypatch):


### PR DESCRIPTION
## Summary
- keep record of visited NPCs
- search for trainers using `/find` when no coordinates are found
- visit fallback locations when searching for trainers
- test the enhanced trainer search logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b1c9cf8d48331b8330f75b6626519