### PR TITLE
Add trainer lookup CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ You can further control the selection with these options:
 
 Every run appends the chosen quest to `logs/quest_selections.log`.
 
+## Trainer Lookup CLI
+Locate the in-game coordinates for a profession trainer.
+
+```bash
+python scripts/cli/find_trainer.py artisan --planet tatooine --city mos_eisley
+```
+
+The `profession` argument is required. `--planet` and `--city` default to
+`tatooine` and `mos_eisley`. When a matching entry is found in
+`data/trainers.yaml`, the trainer's name and coordinates are printed; otherwise
+a helpful message is shown.
+
 ## Log Files
 The application writes several logs under the `logs/` directory:
 

--- a/scripts/cli/find_trainer.py
+++ b/scripts/cli/find_trainer.py
@@ -1,0 +1,29 @@
+import argparse
+from src.training.trainer_data_loader import get_trainer_coords
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Locate trainer coordinates")
+    parser.add_argument("profession", help="Profession to search for")
+    parser.add_argument("--planet", default="tatooine", help="Planet name")
+    parser.add_argument("--city", default="mos_eisley", help="City name")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    result = get_trainer_coords(args.profession, args.planet, args.city)
+    if result:
+        name, x, y = result
+        print(f"{name} at ({x}, {y}) in {args.city.title()}, {args.planet.title()}")
+        return result
+    else:
+        print(
+            f"No trainer found for {args.profession} in {args.city}, {args.planet}."
+        )
+        print("Check trainers.yaml for available locations.")
+        return None
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_find_trainer_cli.py
+++ b/tests/test_find_trainer_cli.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.cli import find_trainer
+
+
+def test_cli_reports_coords(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "artisan", "--planet", "tatooine", "--city", "mos_eisley"])
+    reload(find_trainer)
+    monkeypatch.setattr(find_trainer, "get_trainer_coords", lambda p, pl, c: ("Trainer", 1, 2))
+    find_trainer.main()
+    out = capsys.readouterr().out
+    assert "Trainer" in out
+    assert "(1, 2)" in out
+
+
+def test_cli_handles_missing(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", "brawler"])
+    reload(find_trainer)
+    monkeypatch.setattr(find_trainer, "get_trainer_coords", lambda *a, **k: None)
+    find_trainer.main()
+    out = capsys.readouterr().out
+    assert "No trainer found" in out


### PR DESCRIPTION
## Summary
- add `find_trainer.py` CLI to query trainer coordinates
- document CLI usage in the README
- test CLI behaviour for found/missing trainers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b1df237808331b76ec39593e04c11