### PR TITLE
Update docs for quest selector and trainers

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -4,9 +4,10 @@
 - **XP tracking**: `xp_manager.py`, `xp_session.py`, and `xp_tracker.py` allow recording actions and saving session logs.
 - **Mode runner**: `main.py` and `runner.py` provide CLI entry points to launch different automation modes.
 - **Quest database**: `src/db` holds SQLite schema, quest insertion helpers, and utilities for viewing quests.
+- **Training helpers**: `trainer_data_loader.py`, `trainer_visit.py`, and the `find_trainer.py` CLI locate NPC trainers and automate visits.
 
 ## Modules Needing Work
-- `quest_selector.py` – now includes `select_quest()` stub returning `None`; needs real selection logic.
+- `quest_selector.py` – loads legacy quests and DB entries with filtering support; still needs scoring improvements.
 - `quest_executor.py` – provides `execute_quest()` placeholder; expand with automation steps.
 - `utils/source_verifier.py` – provides helpers for verifying quest data and detecting file changes.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ The `profession` argument is required. `--planet` and `--city` default to
 `data/trainers.yaml`, the trainer's name and coordinates are printed; otherwise
 a helpful message is shown.
 
+Automating the visit is possible through `trainer_visit.visit_trainer()`. It
+loads coordinates from the same YAML file and directs an agent to travel to the
+trainer. Dialogue steps referencing "Trainer" trigger `train_with_npc()` to log
+the interaction.
+
 ## Log Files
 The application writes several logs under the `logs/` directory:
 


### PR DESCRIPTION
## Summary
- note new training helpers
- explain visiting trainers in the README
- clarify quest selector's current functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b3fb5ed308331a771ee5dcf4bdb01