### PR TITLE
Add wiki scraper and legacy HTML fetch tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,3 +21,21 @@ if 'numpy' not in sys.modules:
     sys.modules['numpy'] = np_module
 
 sys.modules.setdefault('pyautogui', types.SimpleNamespace(screenshot=lambda *a, **k: sys.modules['PIL.Image'].new('RGB', (1, 1))))
+
+if 'yaml' not in sys.modules:
+    yaml_module = types.ModuleType('yaml')
+    def safe_load(stream):
+        # Minimal trainer data for tests
+        return {
+            'artisan': {
+                'tatooine': {
+                    'mos_eisley': {
+                        'name': 'Artisan Trainer',
+                        'x': 3432,
+                        'y': -4795,
+                    }
+                }
+            }
+        }
+    yaml_module.safe_load = safe_load
+    sys.modules['yaml'] = yaml_module

--- a/tests/test_fetch_legacy_html.py
+++ b/tests/test_fetch_legacy_html.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a stub for the playwright module before importing the target module
+if "playwright" not in sys.modules:
+    playwright_mod = types.ModuleType("playwright")
+    sync_api_mod = types.ModuleType("playwright.sync_api")
+    playwright_mod.sync_api = sync_api_mod
+    sync_api_mod.sync_playwright = lambda: None
+    sys.modules["playwright"] = playwright_mod
+    sys.modules["playwright.sync_api"] = sync_api_mod
+
+from utils import fetch_legacy_html
+
+
+def test_fetch_legacy_quest_html_saves(monkeypatch, tmp_path):
+    html_content = "<html>legacy</html>"
+    visited = {}
+
+    class DummyPage:
+        def goto(self, url, wait_until=None):
+            visited["url"] = url
+        def content(self):
+            return html_content
+
+    class DummyBrowser:
+        def __init__(self):
+            self.page = DummyPage()
+        def new_page(self):
+            return self.page
+        def close(self):
+            visited["closed"] = True
+
+    def launch(headless=True):
+        return DummyBrowser()
+
+    def fake_sync_playwright():
+        class Manager:
+            def __enter__(self, *a, **k):
+                return types.SimpleNamespace(chromium=types.SimpleNamespace(launch=launch))
+            def __exit__(self, exc_type, exc, tb):
+                pass
+        return Manager()
+
+    monkeypatch.setattr(fetch_legacy_html, "sync_playwright", fake_sync_playwright)
+    out_file = tmp_path / "legacy.html"
+    monkeypatch.setattr(fetch_legacy_html, "OUTPUT_PATH", out_file)
+
+    fetch_legacy_html.fetch_legacy_quest_html()
+
+    assert visited["url"] == fetch_legacy_html.LEGACY_QUEST_URL
+    assert out_file.exists()
+    assert out_file.read_text() == html_content

--- a/tests/test_wiki_scraper.py
+++ b/tests/test_wiki_scraper.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import types
+import pytest
+
+# Provide a stub for the requests module if it's missing
+if "requests" not in sys.modules:
+    requests_mod = types.ModuleType("requests")
+    requests_mod.get = lambda *a, **k: None
+    sys.modules["requests"] = requests_mod
+
+# Stub out BeautifulSoup dependency if missing
+if "bs4" not in sys.modules:
+    bs4_mod = types.ModuleType("bs4")
+    bs4_mod.BeautifulSoup = object
+    sys.modules["bs4"] = bs4_mod
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import wiki_scraper
+
+
+def test_fetch_page_success(monkeypatch):
+    expected_html = "<html>OK</html>"
+
+    def fake_get(url):
+        assert url == wiki_scraper.WikiScraper.BASE_URL + "page"
+        return types.SimpleNamespace(status_code=200, text=expected_html)
+
+    monkeypatch.setattr(wiki_scraper.requests, "get", fake_get)
+    scraper = wiki_scraper.WikiScraper()
+    html = scraper.fetch_page("page")
+    assert html == expected_html
+
+
+def test_fetch_page_error(monkeypatch):
+    def fake_get(url):
+        return types.SimpleNamespace(status_code=404, text="")
+
+    monkeypatch.setattr(wiki_scraper.requests, "get", fake_get)
+    scraper = wiki_scraper.WikiScraper()
+    with pytest.raises(Exception):
+        scraper.fetch_page("missing")


### PR DESCRIPTION
## Summary
- create tests for wiki scraper and legacy HTML utilities
- stub external dependencies in test suite
- extend conftest with lightweight YAML stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b9843d92883319edcdb9a1a991fcc