### PR TITLE
Ensure trainer YAML loads from project root

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -131,3 +131,24 @@ def test_load_trainers_resolves_default(monkeypatch, tmp_path):
     monkeypatch.setattr("builtins.open", fake_open)
     lt.load_trainers()
     assert calls["path"] == lt.TRAINER_FILE
+
+
+def test_load_trainers_default_path(monkeypatch, tmp_path):
+    """load_trainers should read from data/trainers.yaml when no overrides are provided."""
+    import io
+
+    from utils import load_trainers as lt
+
+    calls = {}
+
+    def fake_open(path, *a, **k):
+        calls["path"] = Path(path)
+        return io.StringIO("")
+
+    monkeypatch.delenv("TRAINER_FILE", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("builtins.open", fake_open)
+    lt.load_trainers()
+    expected = Path(__file__).resolve().parents[1] / "data" / "trainers.yaml"
+    assert lt.TRAINER_FILE == expected
+    assert calls["path"] == expected

--- a/utils/load_trainers.py
+++ b/utils/load_trainers.py
@@ -5,7 +5,7 @@ import logging
 
 # Path to the YAML file containing trainer locations. Resolved relative to this
 # module to avoid depending on the caller's working directory.
-TRAINER_FILE = Path(__file__).resolve().parents[2] / "data" / "trainers.yaml"
+TRAINER_FILE = Path(__file__).resolve().parents[1] / "data" / "trainers.yaml"
 
 
 def load_trainers(trainer_file=None):


### PR DESCRIPTION
## Summary
- fix default path in `load_trainers` so it resolves one directory up
- add regression test verifying the path to `data/trainers.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ba050740c8331ae1a227ce054f458