### PR TITLE
Add trainer extraction script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ loads coordinates from the same YAML file and directs an agent to travel to the
 trainer. Dialogue steps referencing "Trainer" trigger `train_with_npc()` to log
 the interaction.
 
+## Trainer Data Extraction
+Generate trainer location entries from sample screenshots.
+
+```bash
+python scripts/data/extract_trainers.py
+```
+
+The script runs OCR on images under `docs/samples/` and writes structured
+results to `data/trainers.yaml`.
+
 ## Log Files
 The application writes several logs under the `logs/` directory:
 

--- a/scripts/data/extract_trainers.py
+++ b/scripts/data/extract_trainers.py
@@ -1,0 +1,70 @@
+import os
+from pathlib import Path
+import cv2
+import yaml
+
+from src.vision.ocr import extract_text
+
+SAMPLES_DIR = Path("docs/samples")
+OUT_FILE = Path("data/trainers.yaml")
+
+
+def _parse_info(text: str) -> dict:
+    """Parse key-value pairs from OCR text."""
+    info = {}
+    for line in text.splitlines():
+        if ':' in line:
+            key, val = line.split(':', 1)
+            info[key.strip().lower()] = val.strip()
+    return info
+
+
+def _load_existing() -> dict:
+    if OUT_FILE.exists():
+        with open(OUT_FILE, 'r') as fh:
+            return yaml.safe_load(fh) or {}
+    return {}
+
+
+def _update(data: dict, info: dict) -> None:
+    required = {'profession', 'planet', 'city', 'name', 'x', 'y'}
+    if not required.issubset(info):
+        return
+    prof = info['profession'].lower()
+    planet = info['planet'].lower()
+    city = info['city'].lower()
+    entry = {
+        'name': info['name'],
+        'x': int(info['x']),
+        'y': int(info['y']),
+    }
+    data.setdefault(prof, {}).setdefault(planet, {})[city] = entry
+
+
+def process_samples() -> None:
+    if not SAMPLES_DIR.exists():
+        print(f"No samples directory found at {SAMPLES_DIR}")
+        return
+
+    data = _load_existing()
+
+    for img_path in sorted(SAMPLES_DIR.iterdir()):
+        if img_path.suffix.lower() not in {'.png', '.jpg', '.jpeg'}:
+            continue
+        img = cv2.imread(str(img_path))
+        if img is None:
+            continue
+        text = extract_text(img)
+        info = _parse_info(text)
+        _update(data, info)
+
+    with open(OUT_FILE, 'w') as fh:
+        yaml.safe_dump(data, fh)
+
+
+def main(argv=None):
+    process_samples()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_extract_trainers.py
+++ b/tests/test_extract_trainers.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.data import extract_trainers
+
+
+def test_extract_trainers_writes_yaml(monkeypatch, tmp_path):
+    samples = tmp_path / "samples"
+    samples.mkdir()
+    (samples / "trainer.png").write_bytes(b"fake")
+
+    out_file = tmp_path / "trainers.yaml"
+
+    monkeypatch.setattr(extract_trainers, "SAMPLES_DIR", samples)
+    monkeypatch.setattr(extract_trainers, "OUT_FILE", out_file)
+
+    monkeypatch.setattr(extract_trainers.cv2, "imread", lambda p: "img", raising=False)
+
+    text = (
+        "profession: artisan\n"
+        "planet: tatooine\n"
+        "city: mos_eisley\n"
+        "name: Sample Trainer\n"
+        "x: 1\n"
+        "y: 2"
+    )
+    monkeypatch.setattr(extract_trainers, "extract_text", lambda img: text)
+
+    monkeypatch.setattr(extract_trainers.yaml, "safe_load", lambda s: {})
+    monkeypatch.setattr(
+        extract_trainers.yaml,
+        "safe_dump",
+        lambda d, fh: fh.write(str(d)),
+        raising=False,
+    )
+
+    extract_trainers.main()
+
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert "Sample Trainer" in content
+    assert "artisan" in content


### PR DESCRIPTION
## Summary
- create `extract_trainers.py` script for parsing sample screenshots with OCR
- document trainer extraction in README
- add unit test for the new script

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ba1102c7c8331af15a9c5653cc47d