### PR TITLE
Refactor navigator to use shared trainer loader

### DIFF
--- a/scripts/logic/trainer_navigator.py
+++ b/scripts/logic/trainer_navigator.py
@@ -29,11 +29,6 @@ def _distance(a: Coords, b: Coords) -> float:
     return math.hypot(a[0] - b[0], a[1] - b[1])
 
 
-def load_trainer_data(trainer_file: Optional[str] = None) -> Dict[str, dict]:
-    """Wrapper around :func:`load_trainers` for external use."""
-    return load_trainers(trainer_file)
-
-
 def find_nearby_trainers(
     player_pos: Coords,
     planet: str,
@@ -47,7 +42,10 @@ def find_nearby_trainers(
     The returned list contains dictionaries with ``profession``, ``name``,
     ``x``, ``y`` and ``distance`` keys sorted by distance.
     """
-    data = load_trainer_data(trainer_file)
+    # Delegate reading trainer data to :func:`utils.load_trainers.load_trainers`
+    # so callers benefit from environment variable overrides and consistent
+    # path handling.
+    data = load_trainers(trainer_file)
     results: List[Dict[str, object]] = []
 
     for profession, planets in data.items():

--- a/tests/test_trainer_navigator.py
+++ b/tests/test_trainer_navigator.py
@@ -23,7 +23,7 @@ def test_find_nearby_trainers(monkeypatch):
         "marksman": {"tatooine": {"mos_eisley": {"name": "Mark", "x": 10, "y": 0}}},
     }
     loader = DummyLoad(data)
-    monkeypatch.setattr(tn, "load_trainer_data", loader)
+    monkeypatch.setattr(tn, "load_trainers", loader)
 
     result = tn.find_nearby_trainers((0, 0), "tatooine", "mos_eisley", threshold=11)
     assert loader.called
@@ -38,7 +38,7 @@ def test_threshold(monkeypatch):
         "artisan": {"tatooine": {"mos_eisley": {"name": "Art", "x": 100, "y": 0}}}
     }
     loader = DummyLoad(data)
-    monkeypatch.setattr(tn, "load_trainer_data", loader)
+    monkeypatch.setattr(tn, "load_trainers", loader)
 
     result = tn.find_nearby_trainers((0, 0), "tatooine", "mos_eisley", threshold=50)
     assert result == []


### PR DESCRIPTION
## Summary
- simplify `trainer_navigator` by calling `load_trainers` directly
- update navigator tests to patch `load_trainers`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c23220efc83318eae1fbc3ea9b2a1