### PR TITLE
Add trainer navigation function and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ loads coordinates from the same YAML file and directs an agent to travel to the
 trainer. Dialogue steps referencing "Trainer" trigger `train_with_npc()` to log
 the interaction.
 
+## Trainer Navigation CLI
+Navigate and log a trainer visit in one step:
+
+```bash
+python cli/trainer/find_trainer.py --trainer "Master Combat Medic"
+```
+
+The command accepts the same `--planet` and `--city` options as the lookup
+script, defaulting to `tatooine` and `mos_eisley`.
+
 ## Trainer Navigator Script
 `scripts/logic/trainer_navigator.py` exposes helper functions for locating
 nearby trainers and logging training sessions. It expects a YAML file at

--- a/cli/trainer/find_trainer.py
+++ b/cli/trainer/find_trainer.py
@@ -1,0 +1,19 @@
+import argparse
+from scripts.logic.trainer_navigator import navigate_to_trainer
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Navigate to a profession trainer")
+    parser.add_argument("--trainer", required=True, help="Trainer profession name")
+    parser.add_argument("--planet", default="tatooine", help="Planet name")
+    parser.add_argument("--city", default="mos_eisley", help="City name")
+    return parser.parse_args(argv)
+
+
+def main(argv=None, agent=None):
+    args = _parse_args(argv)
+    return navigate_to_trainer(args.trainer, args.planet, args.city, agent)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trainer_find_cli.py
+++ b/tests/test_trainer_find_cli.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cli.trainer import find_trainer
+
+
+def test_cli_invokes_navigate(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--trainer", "artisan"])
+    reload(find_trainer)
+    called = {}
+    monkeypatch.setattr(find_trainer, "navigate_to_trainer", lambda t, p, c, a: called.setdefault("args", (t, p, c, a)))
+    find_trainer.main()
+    assert called["args"] == ("artisan", "tatooine", "mos_eisley", None)
+
+
+def test_cli_custom_options(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--trainer", "marksman", "--planet", "corellia", "--city", "coronet"])
+    reload(find_trainer)
+    called = {}
+    monkeypatch.setattr(find_trainer, "navigate_to_trainer", lambda t, p, c, a: called.setdefault("args", (t, p, c, a)))
+    find_trainer.main()
+    assert called["args"] == ("marksman", "corellia", "coronet", None)

--- a/tests/test_trainer_navigator.py
+++ b/tests/test_trainer_navigator.py
@@ -82,3 +82,22 @@ def test_log_training_event_default_appends(monkeypatch, tmp_path):
     second = log_file.read_text().splitlines()
     assert len(second) == 2
     assert first[0] != second[1]
+
+
+def test_navigate_to_trainer_calls_helpers(monkeypatch):
+    calls = {}
+
+    def fake_visit(agent, prof, planet="tatooine", city="mos_eisley"):
+        calls["visit"] = (agent, prof, planet, city)
+
+    def fake_log(prof, name, dist, log_path=tn.DEFAULT_LOG_PATH):
+        calls["log"] = (prof, name, dist)
+
+    monkeypatch.setattr(tn, "visit_trainer", fake_visit)
+    monkeypatch.setattr(tn, "log_training_event", fake_log)
+    monkeypatch.setattr(tn, "get_trainer_location", lambda *a, **k: ("Trainer", 1, 2))
+
+    tn.navigate_to_trainer("artisan", "tatooine", "mos_eisley", agent="A")
+
+    assert calls["visit"] == ("A", "artisan", "tatooine", "mos_eisley")
+    assert calls["log"] == ("artisan", "Trainer", 0.0)


### PR DESCRIPTION
## Summary
- support travelling to and logging visits to trainers via `navigate_to_trainer`
- expose a new CLI command `cli/trainer/find_trainer.py`
- document the new command in the README
- test trainer navigation function and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c32f0d94883318504973f6b4b3b49