### PR TITLE
Add trainer visit check for questing

### DIFF
--- a/scripts/logic/trainer_check.py
+++ b/scripts/logic/trainer_check.py
@@ -1,0 +1,11 @@
+"""Skill training recommendation logic."""
+
+from __future__ import annotations
+
+import random
+
+
+def should_train_skills() -> bool:
+    """Return ``True`` if a trainer visit is recommended."""
+    # Placeholder heuristic: randomly choose whether to train.
+    return random.random() < 0.2

--- a/src/automation/automator.py
+++ b/src/automation/automator.py
@@ -4,6 +4,7 @@ from src.vision.ocr import capture_screen, extract_text
 from src.vision.states import detect_state, handle_state
 from src.utils.logger import save_screenshot, log_ocr_text
 from . import mode_manager
+from .quest_path import visit_trainer_if_needed
 
 
 def _questing_behavior() -> None:
@@ -19,6 +20,7 @@ def _questing_behavior() -> None:
         handle_state(state)
     else:
         print("[NO MATCH] Continuing scan...")
+        visit_trainer_if_needed()
 
 
 def _combat_behavior() -> None:

--- a/src/automation/quest_path.py
+++ b/src/automation/quest_path.py
@@ -1,0 +1,37 @@
+"""Questing helpers for navigation and training."""
+
+from __future__ import annotations
+
+from scripts.logic.trainer_check import should_train_skills
+from scripts.logic.trainer_navigator import navigate_to_trainer
+
+
+def visit_trainer_if_needed(
+    agent=None,
+    *,
+    trainer: str = "artisan",
+    planet: str = "tatooine",
+    city: str = "mos_eisley",
+) -> bool:
+    """Visit the profession trainer if training is recommended.
+
+    Parameters
+    ----------
+    agent:
+        Optional automation agent passed through to :func:`navigate_to_trainer`.
+    trainer:
+        Profession name of the trainer to visit.
+    planet:
+        Planet where the trainer resides.
+    city:
+        City where the trainer resides.
+
+    Returns
+    -------
+    bool
+        ``True`` when a trainer visit was triggered.
+    """
+    if should_train_skills():
+        navigate_to_trainer(trainer, planet, city, agent)
+        return True
+    return False

--- a/tests/test_quest_path.py
+++ b/tests/test_quest_path.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import src.automation.quest_path as qp
+
+
+def test_visit_trainer_invokes_navigation(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(qp, "should_train_skills", lambda: True)
+    monkeypatch.setattr(qp, "navigate_to_trainer", lambda t, p, c, a: calls.setdefault("args", (t, p, c, a)))
+    result = qp.visit_trainer_if_needed(agent="A", trainer="artisan")
+    assert result is True
+    assert calls["args"] == ("artisan", "tatooine", "mos_eisley", "A")
+
+
+def test_visit_trainer_skipped(monkeypatch):
+    monkeypatch.setattr(qp, "should_train_skills", lambda: False)
+    called = []
+    monkeypatch.setattr(qp, "navigate_to_trainer", lambda *a, **k: called.append(True))
+    result = qp.visit_trainer_if_needed()
+    assert result is False
+    assert not called


### PR DESCRIPTION
## Summary
- add `should_train_skills` helper under `scripts.logic`
- implement `visit_trainer_if_needed` in new `src/automation/quest_path` module
- call `visit_trainer_if_needed` from questing behavior
- test conditional trainer visit logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c3475a06c8331ae994167c2e4f60a