### PR TITLE
Add session logging for trainer visits

### DIFF
--- a/scripts/logic/trainer_navigator.py
+++ b/scripts/logic/trainer_navigator.py
@@ -17,6 +17,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 from utils.load_trainers import load_trainers
 from utils.get_trainer_location import get_trainer_location
 from src.training.trainer_visit import visit_trainer
+from src.utils.logger import log_event
 
 # Default log file under the project's ``logs`` directory.
 DEFAULT_LOG_PATH = os.path.join("logs", "training_log.txt")
@@ -104,6 +105,8 @@ def navigate_to_trainer(
     :func:`log_training_event`.
     """
 
+    log_event(f"Starting trainer visit: {trainer_name} in {city}, {planet}")
+
     location = get_trainer_location(trainer_name, planet, city)
     if not location:
         data = load_trainers()
@@ -123,5 +126,8 @@ def navigate_to_trainer(
         log_training_event(trainer_name, location[0], 0.0)
     else:
         log_training_event(trainer_name, f"{trainer_name} trainer", 0.0)
+
+    log_event(f"Completed trainer visit: {trainer_name} in {city}, {planet}")
+
     return location
 

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -4,6 +4,7 @@ import cv2
 
 SCREENSHOT_DIR = os.path.join("logs", "screenshots")
 OCR_LOG_PATH = os.path.join("logs", "ocr_text.log")
+SESSION_LOG_PATH = os.path.join("logs", "session.log")
 
 
 def save_screenshot(image, *, directory: str = SCREENSHOT_DIR) -> str:
@@ -27,4 +28,16 @@ def log_ocr_text(text: str, *, log_path: str = OCR_LOG_PATH) -> str:
             f.write(f"{timestamp} | {text}\n")
     except Exception as e:  # pragma: no cover - best effort logging
         print(f"[LOGGER] Failed to log OCR text: {e}")
+    return log_path
+
+
+def log_event(message: str, *, log_path: str = SESSION_LOG_PATH) -> str:
+    """Append ``message`` to ``log_path`` with a timestamp."""
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    timestamp = datetime.datetime.now().isoformat()
+    try:
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(f"{timestamp} | {message}\n")
+    except Exception as e:  # pragma: no cover - best effort logging
+        print(f"[LOGGER] Failed to log event: {e}")
     return log_path

--- a/tests/test_trainer_navigator.py
+++ b/tests/test_trainer_navigator.py
@@ -101,3 +101,19 @@ def test_navigate_to_trainer_calls_helpers(monkeypatch):
 
     assert calls["visit"] == ("A", "artisan", "tatooine", "mos_eisley")
     assert calls["log"] == ("artisan", "Trainer", 0.0)
+
+
+def test_navigate_to_trainer_logs_events(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(tn, "visit_trainer", lambda *a, **k: None)
+    monkeypatch.setattr(tn, "log_training_event", lambda *a, **k: None)
+    monkeypatch.setattr(tn, "get_trainer_location", lambda *a, **k: ("Trainer", 1, 2))
+
+    tn.navigate_to_trainer("artisan", "tatooine", "mos_eisley", agent="A")
+
+    log_file = tmp_path / "logs" / "session.log"
+    assert log_file.exists()
+    lines = log_file.read_text().splitlines()
+    assert any("Starting trainer visit" in l for l in lines)
+    assert any("Completed trainer visit" in l for l in lines)

--- a/tests/test_utils_logger.py
+++ b/tests/test_utils_logger.py
@@ -24,3 +24,12 @@ def test_log_ocr_text(tmp_path):
     content = log_file.read_text()
     assert "hello" in content
 
+
+def test_log_event(tmp_path):
+    from src.utils import logger
+    log_file = tmp_path / "ev.log"
+    logger.log_event("hi", log_path=str(log_file))
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "hi" in content
+


### PR DESCRIPTION
## Summary
- add `log_event` helper for timestamped session logs
- track start and completion of trainer visits
- verify event logging in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c35e3f5b08331911ddc410e684572