### PR TITLE
Add profession wiki importer

### DIFF
--- a/scripts/importers/profession_importer.py
+++ b/scripts/importers/profession_importer.py
@@ -1,0 +1,77 @@
+import os
+import json
+import re
+import requests
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://swgr.org/wiki/"
+OUTPUT_DIR = os.path.join("android_ms11", "data", "professions")
+
+
+def fetch_profession_html(name: str) -> str:
+    url = f"{BASE_URL}{name}/"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.text
+
+
+def parse_profession_html(html: str) -> dict:
+    soup = BeautifulSoup(html, "html.parser")
+
+    prereqs: list[str] = []
+    skill_boxes: list[str] = []
+    xp_costs: dict[str, int] = {}
+
+    # find prerequisites list
+    pre = soup.find(string=lambda t: t and "Prerequisite" in t)
+    if pre:
+        ul = pre.find_parent().find_next("ul")
+        if ul:
+            prereqs = [li.get_text(strip=True) for li in ul.find_all("li")]
+
+    # find skill tree/boxes
+    skill = soup.find(string=lambda t: t and "Skill" in t and ("Tree" in t or "Boxes" in t))
+    if skill:
+        ul = skill.find_parent().find_next("ul")
+        if ul:
+            for li in ul.find_all("li"):
+                text = li.get_text(strip=True)
+                skill_boxes.append(text)
+                m = re.search(r"([0-9,]+)\s*[A-Za-z]*\s*XP", text)
+                if m:
+                    xp = int(m.group(1).replace(",", ""))
+                    name = re.sub(r"\([^)]*\)", "", text).strip()
+                    xp_costs[name] = xp
+
+    return {
+        "prerequisites": prereqs,
+        "skill_boxes": skill_boxes,
+        "xp_costs": xp_costs,
+    }
+
+
+def save_profession_data(name: str, data: dict) -> str:
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    out_path = os.path.join(OUTPUT_DIR, f"{name.lower()}.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    return out_path
+
+
+def fetch_and_save(name: str) -> str:
+    html = fetch_profession_html(name)
+    data = parse_profession_html(html)
+    return save_profession_data(name, data)
+
+
+def main(argv=None):
+    import argparse
+    parser = argparse.ArgumentParser(description="Import profession data from SWGR wiki")
+    parser.add_argument("profession", help="Profession name, e.g. Architect")
+    args = parser.parse_args(argv)
+    path = fetch_and_save(args.profession)
+    print(f"Saved to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_profession_importer.py
+++ b/tests/test_profession_importer.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import json
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.importers import profession_importer
+
+
+def test_fetch_and_save(monkeypatch, tmp_path):
+    sample_html = (
+        "<h3>Prerequisites</h3>"
+        "<ul><li>Novice Artisan</li><li>Combat Level 5</li></ul>"
+        "<h3>Skill Tree</h3>"
+        "<ul>"
+        "<li>Novice Medic (General Crafting XP)</li>"
+        "<li>Advanced Medicine (1,000 Medicine XP)</li>"
+        "<li>Master Doctor (10,000 Medicine XP)</li>"
+        "</ul>"
+    )
+
+    class DummyResponse:
+        status_code = 200
+        text = sample_html
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url):
+        assert url == profession_importer.BASE_URL + "Doctor/"
+        return DummyResponse()
+
+    monkeypatch.setattr(profession_importer.requests, "get", fake_get)
+    out_dir = tmp_path / "professions"
+    monkeypatch.setattr(profession_importer, "OUTPUT_DIR", out_dir)
+
+    profession_importer.fetch_and_save("Doctor")
+
+    out_file = out_dir / "doctor.json"
+    assert out_file.exists()
+    data = json.loads(out_file.read_text())
+    assert data["prerequisites"] == ["Novice Artisan", "Combat Level 5"]
+    assert "Novice Medic (General Crafting XP)" in data["skill_boxes"]
+    assert data["xp_costs"]["Advanced Medicine"] == 1000
+    assert data["xp_costs"]["Master Doctor"] == 10000


### PR DESCRIPTION
## Summary
- implement `profession_importer` to fetch & parse SWGR wiki profession pages
- write scraped data to `android_ms11/data/professions/<name>.json`
- test profession importer with mocked HTTP response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c70b3aee08331aaa4e6f559cb87c4