### PR TITLE
Add shuttle travel utilities and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,31 @@ python scripts/data/extract_trainers.py
 The script runs OCR on images under `docs/samples/` and writes structured
 results to `data/trainers.yaml`.
 
+## Shuttle Travel Utilities
+Shuttle locations and connections are defined in `data/shuttles.json`. Each
+planet key contains a list of shuttles with NPC coordinates and destination
+links. A minimal entry looks like:
+
+```json
+{
+  "tatooine": [
+    {
+      "city": "mos_eisley",
+      "npc": "Shuttle Conductor",
+      "x": 3520,
+      "y": -4800,
+      "destinations": [
+        {"planet": "corellia", "city": "coronet"}
+      ]
+    }
+  ]
+}
+```
+
+Utilities under `scripts/travel/` read this file to determine the nearest
+shuttle and to plan multi-hop routes. After traveling, `navigate_to(city, agent)`
+walks the agent from the shuttle to the destination coordinates.
+
 ## Log Files
 The application writes several logs under the `logs/` directory:
 

--- a/data/shuttles.json
+++ b/data/shuttles.json
@@ -1,0 +1,33 @@
+{
+  "tatooine": [
+    {
+      "city": "mos_eisley",
+      "npc": "Shuttle Conductor",
+      "x": 3520,
+      "y": -4800,
+      "destinations": [
+        {"planet": "corellia", "city": "coronet"}
+      ]
+    },
+    {
+      "city": "anchorhead",
+      "npc": "Shuttle Attendant",
+      "x": -100,
+      "y": 200,
+      "destinations": [
+        {"planet": "tatooine", "city": "mos_eisley"}
+      ]
+    }
+  ],
+  "corellia": [
+    {
+      "city": "coronet",
+      "npc": "Shuttle Conductor",
+      "x": 123,
+      "y": 456,
+      "destinations": [
+        {"planet": "tatooine", "city": "mos_eisley"}
+      ]
+    }
+  ]
+}

--- a/scripts/travel/shuttle.py
+++ b/scripts/travel/shuttle.py
@@ -1,0 +1,129 @@
+"""Shuttle travel utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import deque
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from src.movement.movement_profiles import travel_to_city, walk_to_coords
+
+# Path to the default shuttle configuration file under ``data``.
+SHUTTLE_FILE = Path(__file__).resolve().parents[1] / "data" / "shuttles.json"
+
+# Type aliases for clarity
+Coords = Tuple[int, int]
+ShuttleEntry = Dict[str, object]
+
+
+def load_shuttles(shuttle_file: Optional[str] = None) -> Dict[str, List[ShuttleEntry]]:
+    """Return shuttle configuration data from ``shuttle_file``.
+
+    The ``SHUTTLE_FILE`` environment variable overrides the default path.
+    """
+    env_override = os.environ.get("SHUTTLE_FILE")
+    path = Path(shuttle_file or env_override or SHUTTLE_FILE)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {}
+
+
+def _distance(a: Coords, b: Coords) -> float:
+    """Return the Euclidean distance between two points."""
+    return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2) ** 0.5
+
+
+def _lookup_entry(data: Dict[str, List[ShuttleEntry]], planet: str, city: str) -> Optional[ShuttleEntry]:
+    for entry in data.get(planet, []):
+        if entry.get("city") == city:
+            return entry
+    return None
+
+
+def nearest_shuttle(
+    position: Coords, planet: str, shuttle_data: Optional[Dict[str, List[ShuttleEntry]]] = None
+) -> Optional[ShuttleEntry]:
+    """Return the closest shuttle entry to ``position`` on ``planet``."""
+    data = shuttle_data or load_shuttles()
+    best: Optional[ShuttleEntry] = None
+    for entry in data.get(planet, []):
+        dist = _distance(position, (entry.get("x", 0), entry.get("y", 0)))
+        if best is None or dist < best.get("distance", float("inf")):
+            best = dict(entry)
+            best["distance"] = dist
+    return best
+
+
+def plan_route(
+    start_city: str,
+    dest_city: str,
+    *,
+    start_planet: str = "tatooine",
+    dest_planet: Optional[str] = None,
+    shuttle_data: Optional[Dict[str, List[ShuttleEntry]]] = None,
+) -> List[ShuttleEntry]:
+    """Return the shuttle stops needed to travel from ``start_city`` to ``dest_city``."""
+    data = shuttle_data or load_shuttles()
+    if dest_planet is None:
+        dest_planet = start_planet
+
+    graph = {}
+    for planet, entries in data.items():
+        for entry in entries:
+            node = (planet, entry.get("city"))
+            graph[node] = [(d["planet"], d["city"]) for d in entry.get("destinations", [])]
+
+    start = (start_planet, start_city)
+    dest = (dest_planet, dest_city)
+
+    queue: deque[Tuple[Tuple[str, str], List[Tuple[str, str]]]] = deque([(start, [start])])
+    visited = set()
+
+    while queue:
+        node, path = queue.popleft()
+        if node == dest:
+            result = []
+            for p, c in path:
+                entry = _lookup_entry(data, p, c) or {"city": c, "x": 0, "y": 0}
+                result.append({"planet": p, **entry})
+            return result
+        if node in visited:
+            continue
+        visited.add(node)
+        for nxt in graph.get(node, []):
+            if nxt not in visited:
+                queue.append((nxt, path + [nxt]))
+    return []
+
+
+def navigate_to(
+    city: str,
+    agent,
+    *,
+    start_city: str = "mos_eisley",
+    start_planet: str = "tatooine",
+    dest_planet: Optional[str] = None,
+    shuttle_file: Optional[str] = None,
+) -> None:
+    """Travel to ``city`` then walk to its shuttle coordinates."""
+    data = load_shuttles(shuttle_file)
+    route = plan_route(
+        start_city,
+        city,
+        start_planet=start_planet,
+        dest_planet=dest_planet or start_planet,
+        shuttle_data=data,
+    )
+    if not route:
+        return
+
+    # Walk the route one city at a time
+    for stop in route[1:]:
+        travel_to_city(agent, stop["city"])
+
+    dest_entry = route[-1]
+    walk_to_coords(agent, dest_entry.get("x", 0), dest_entry.get("y", 0))

--- a/tests/test_shuttle_travel.py
+++ b/tests/test_shuttle_travel.py
@@ -1,0 +1,75 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.travel import shuttle
+
+
+sample_data = {
+    "tatooine": [
+        {
+            "city": "mos_eisley",
+            "npc": "Shuttle Conductor",
+            "x": 0,
+            "y": 0,
+            "destinations": [{"planet": "corellia", "city": "coronet"}],
+        },
+        {
+            "city": "anchorhead",
+            "npc": "Shuttle Attendant",
+            "x": 100,
+            "y": 0,
+            "destinations": [{"planet": "tatooine", "city": "mos_eisley"}],
+        },
+    ],
+    "corellia": [
+        {
+            "city": "coronet",
+            "npc": "Shuttle Conductor",
+            "x": 10,
+            "y": 0,
+            "destinations": [{"planet": "tatooine", "city": "mos_eisley"}],
+        }
+    ],
+}
+
+
+def test_nearest_shuttle():
+    res = shuttle.nearest_shuttle((80, 0), "tatooine", sample_data)
+    assert res["city"] == "anchorhead"
+
+
+def test_plan_route_simple():
+    route = shuttle.plan_route(
+        "mos_eisley",
+        "coronet",
+        start_planet="tatooine",
+        dest_planet="corellia",
+        shuttle_data=sample_data,
+    )
+    assert [r["city"] for r in route] == ["mos_eisley", "coronet"]
+
+
+def test_navigate_to_invokes_movement(monkeypatch):
+    calls = []
+
+    def fake_travel(agent, city):
+        calls.append(("travel", city))
+
+    def fake_walk(agent, x, y):
+        calls.append(("walk", x, y))
+
+    monkeypatch.setattr(shuttle, "travel_to_city", fake_travel)
+    monkeypatch.setattr(shuttle, "walk_to_coords", fake_walk)
+    monkeypatch.setattr(shuttle, "load_shuttles", lambda f=None: sample_data)
+
+    shuttle.navigate_to(
+        "coronet",
+        agent="A",
+        start_city="mos_eisley",
+        start_planet="tatooine",
+        dest_planet="corellia",
+    )
+
+    assert calls == [("travel", "coronet"), ("walk", 10, 0)]


### PR DESCRIPTION
## Summary
- create `scripts/travel` package with shuttle utilities
- add sample `data/shuttles.json`
- document shuttle config format in README
- provide tests for shuttle planning helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c71f918a48331ac6554987b2eadb7