### PR TITLE
Add profession progress tracker

### DIFF
--- a/modules/professions/progress_tracker.py
+++ b/modules/professions/progress_tracker.py
@@ -1,0 +1,54 @@
+import json
+import os
+import re
+from typing import List, Optional, Dict
+
+from modules.learning import xp_estimator
+
+DATA_DIR = os.path.join("data", "parsed", "professions")
+
+
+def _skill_name(text: str) -> str:
+    """Return the skill name without any parenthetical notes."""
+    return re.sub(r"\([^)]*\)", "", text).strip()
+
+
+def load_profession(profession: str) -> Dict:
+    """Load profession data from ``DATA_DIR``."""
+    path = os.path.join(DATA_DIR, f"{profession.lower()}.json")
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def has_prerequisites(profession: str, skills: List[str]) -> bool:
+    """Return ``True`` if all profession prerequisites are met."""
+    data = load_profession(profession)
+    prereqs = data.get("prerequisites", [])
+    return all(p in skills for p in prereqs)
+
+
+def recommend_next_skill(profession: str, skills: List[str]) -> Optional[Dict[str, int]]:
+    """Return the next skill box to pursue and its XP cost."""
+    data = load_profession(profession)
+    for prereq in data.get("prerequisites", []):
+        if prereq not in skills:
+            return {"skill": prereq, "xp": 0}
+
+    for entry in data.get("skill_boxes", []):
+        name = _skill_name(entry)
+        if name not in skills:
+            xp_cost = data.get("xp_costs", {}).get(name, 0)
+            return {"skill": name, "xp": xp_cost}
+    return None
+
+
+def estimate_hours_to_next_skill(profession: str, skills: List[str], activity: str) -> Optional[float]:
+    """Estimate hours needed to reach the XP for the next skill."""
+    rec = recommend_next_skill(profession, skills)
+    if not rec or rec["xp"] <= 0:
+        return 0.0 if rec else None
+
+    xp_per_hour = xp_estimator.estimate_xp_per_hour(profession, activity)
+    if xp_per_hour <= 0:
+        return float("inf")
+    return rec["xp"] / xp_per_hour

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.professions import progress_tracker
+
+
+def setup_profession(tmp_path):
+    data = {
+        "prerequisites": ["Novice Artisan"],
+        "skill_boxes": [
+            "Novice Medic",
+            "Intermediate Medicine (1,000 Medicine XP)",
+            "Master Doctor (10,000 Medicine XP)",
+        ],
+        "xp_costs": {
+            "Novice Medic": 0,
+            "Intermediate Medicine": 1000,
+            "Master Doctor": 10000,
+        },
+    }
+    prof_dir = tmp_path
+    prof_dir.mkdir(exist_ok=True)
+    with open(prof_dir / "medic.json", "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+    return prof_dir
+
+
+def test_recommend_next_skill(monkeypatch, tmp_path):
+    prof_dir = setup_profession(tmp_path)
+    monkeypatch.setattr(progress_tracker, "DATA_DIR", str(prof_dir))
+
+    rec = progress_tracker.recommend_next_skill("medic", [])
+    assert rec == {"skill": "Novice Artisan", "xp": 0}
+
+    rec = progress_tracker.recommend_next_skill("medic", ["Novice Artisan"])
+    assert rec == {"skill": "Novice Medic", "xp": 0}
+
+    rec = progress_tracker.recommend_next_skill(
+        "medic", ["Novice Artisan", "Novice Medic"]
+    )
+    assert rec == {"skill": "Intermediate Medicine", "xp": 1000}
+
+    rec = progress_tracker.recommend_next_skill(
+        "medic", ["Novice Artisan", "Novice Medic", "Intermediate Medicine"]
+    )
+    assert rec == {"skill": "Master Doctor", "xp": 10000}
+
+    rec = progress_tracker.recommend_next_skill(
+        "medic",
+        [
+            "Novice Artisan",
+            "Novice Medic",
+            "Intermediate Medicine",
+            "Master Doctor",
+        ],
+    )
+    assert rec is None
+
+
+def test_estimate_hours_to_next_skill(monkeypatch, tmp_path):
+    prof_dir = setup_profession(tmp_path)
+    monkeypatch.setattr(progress_tracker, "DATA_DIR", str(prof_dir))
+    monkeypatch.setattr(progress_tracker.xp_estimator, "estimate_xp_per_hour", lambda p, a: 500)
+
+    hours = progress_tracker.estimate_hours_to_next_skill(
+        "medic", ["Novice Artisan", "Novice Medic"], "healing"
+    )
+    assert hours == 1000 / 500


### PR DESCRIPTION
## Summary
- add profession progress tracker module
- test progress tracker recommendations

## Testing
- `pytest -q tests/test_progress_tracker.py -s`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c8e76b67483319363b863b5e9d745