### PR TITLE
Improve session logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,5 +269,5 @@ The application writes several logs under the `logs/` directory:
 - `logs/app.log` &ndash; general runtime messages produced by `start_log()`.
 - `logs/quest_selections.log` &ndash; history of quests chosen via the CLI.
 - `logs/step_journal.log` &ndash; success/failure records from step validation.
-- `logs/session_*.log` &ndash; detailed step traces for each session.
+- `logs/session_*.json` &ndash; detailed step traces and summaries for each session.
 - `logs/training_log.txt` &ndash; entries recorded by the trainer navigator.

--- a/src/logging/session_log.py
+++ b/src/logging/session_log.py
@@ -1,13 +1,46 @@
+"""Lightweight JSON session logger."""
+
 import datetime
+import json
 import os
 
+# All session logs are written under ``logs/`` with a consistent naming scheme
 log_dir = "logs"
 os.makedirs(log_dir, exist_ok=True)
 timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-log_path = os.path.join(log_dir, f"session_{timestamp}.log")
+log_path = os.path.join(log_dir, f"session_{timestamp}.json")
+
+# Internal structure for the active session
+_session_data = {
+    "start_time": datetime.datetime.now().isoformat(),
+    "quests_completed": 0,
+    "total_xp": 0,
+    "time_spent": 0.0,
+    "activity_breakdown": {},
+    "steps": [],
+}
+_start_dt = datetime.datetime.now()
 
 
-def log_step(step: dict):
-    with open(log_path, "a") as f:
-        entry = f"[{datetime.datetime.now()}] {step['type'].upper()}: {step}\n"
-        f.write(entry)
+def log_step(step: dict) -> None:
+    """Append ``step`` to the JSON log and update summary fields."""
+
+    now = datetime.datetime.now()
+
+    step_type = step.get("type", "unknown")
+    _session_data["activity_breakdown"].setdefault(step_type, 0)
+    _session_data["activity_breakdown"][step_type] += 1
+
+    if step_type == "quest" and step.get("action") == "complete":
+        _session_data["quests_completed"] += 1
+
+    xp = step.get("xp")
+    if isinstance(xp, (int, float)):
+        _session_data["total_xp"] += xp
+
+    _session_data["steps"].append({"time": now.isoformat(), **step})
+
+    _session_data["time_spent"] = (now - _start_dt).total_seconds()
+
+    with open(log_path, "w", encoding="utf-8") as f:
+        json.dump(_session_data, f, indent=2)

--- a/src/xp_session.py
+++ b/src/xp_session.py
@@ -2,7 +2,8 @@ from datetime import datetime
 import json
 import os
 
-LOG_DIR = "data/xp_logs"
+# Store all session logs under the common ``logs/`` directory
+LOG_DIR = "logs"
 os.makedirs(LOG_DIR, exist_ok=True)
 
 
@@ -28,7 +29,9 @@ class XPSession:
         self.xp_gain = xp_end - self.xp_start
 
     def save(self):
-        path = os.path.join(LOG_DIR, f"{self.character}_{self.session_start.replace(':', '-')}.json")
+        """Write the session log to ``logs/session_*.json`` and return the path."""
+        timestamp = self.session_start.replace(":", "-")
+        path = os.path.join(LOG_DIR, f"session_{timestamp}.json")
         with open(path, "w") as f:
             json.dump(self.__dict__, f, indent=2)
         return path

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,7 +7,11 @@ from src.logging.session_log import log_step
 
 
 def test_log_step_creates_file():
-    step = {"type": "test", "value": 123}
+    step = {"type": "test", "value": 123, "xp": 10}
     log_step(step)
-    files = os.listdir("logs")
-    assert any("session_" in f and f.endswith(".log") for f in files)
+    files = [f for f in os.listdir("logs") if f.startswith("session_") and f.endswith(".json")]
+    assert files
+    with open(os.path.join("logs", files[0]), "r", encoding="utf-8") as f:
+        data = __import__("json").load(f)
+    assert data["total_xp"] >= 10
+    assert data["activity_breakdown"]["test"] >= 1

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -54,7 +54,10 @@ def test_run_mode_dispatches(monkeypatch):
 
 
 def test_run_step_list(monkeypatch):
-    monkeypatch.setattr("builtins.open", lambda f, _: __import__("io").StringIO(
-        '[{"type":"quest","id":"intro_mission","action":"start"}]'
-    ))
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda f, _=None, **__: __import__("io").StringIO(
+            '[{"type":"quest","id":"intro_mission","action":"start"}]'
+        ),
+    )
     run_step_list("fake_path.json")


### PR DESCRIPTION
## Summary
- log JSON session data and track progress fields
- unify xp logs under `logs/`
- update tests for new JSON logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ce1ac495c8331bff8e5d62c8f3e72