### PR TITLE
Unify XP log paths

### DIFF
--- a/modules/learning/xp_estimator.py
+++ b/modules/learning/xp_estimator.py
@@ -5,8 +5,8 @@ from typing import List, Dict
 
 from src.xp_tracker import estimate_xp
 from scripts.xp_estimator.static_estimator import StaticXPEstimator
+from src.xp_paths import LOG_ROOT
 
-LOG_ROOT = os.path.join("logs", "xp_tracking")
 os.makedirs(LOG_ROOT, exist_ok=True)
 
 

--- a/scripts/xp_estimator/static_estimator.py
+++ b/scripts/xp_estimator/static_estimator.py
@@ -1,7 +1,9 @@
 import os
 from datetime import datetime
 
-LOG_DIR = "android_ms11/data/logs/xp_tracking"
+from src.xp_paths import LOG_ROOT
+
+LOG_DIR = LOG_ROOT
 LOG_FILE = "xp_actions.log"
 
 

--- a/src/xp_paths.py
+++ b/src/xp_paths.py
@@ -1,0 +1,6 @@
+import os
+
+"""Shared XP logging paths for Android MS11."""
+
+LOG_ROOT = os.path.join("logs", "xp_tracking")
+

--- a/src/xp_session.py
+++ b/src/xp_session.py
@@ -2,8 +2,10 @@ from datetime import datetime
 import json
 import os
 
-# Store all session logs under the common ``logs/`` directory
-LOG_DIR = "logs"
+from .xp_paths import LOG_ROOT
+
+# Store all XP session logs under the shared ``logs/xp_tracking`` directory
+LOG_DIR = LOG_ROOT
 os.makedirs(LOG_DIR, exist_ok=True)
 
 
@@ -29,7 +31,7 @@ class XPSession:
         self.xp_gain = xp_end - self.xp_start
 
     def save(self):
-        """Write the session log to ``logs/session_*.json`` and return the path."""
+        """Write the session log to ``logs/xp_tracking/session_*.json`` and return the path."""
         timestamp = self.session_start.replace(":", "-")
         path = os.path.join(LOG_DIR, f"session_{timestamp}.json")
         with open(path, "w") as f:


### PR DESCRIPTION
## Summary
- centralize XP log root in `src/xp_paths.py`
- store `XPSession` files under `logs/xp_tracking`
- make `StaticXPEstimator` use same directory
- update learning estimator to import the new path

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ce3dd67288331b85cfe9cf7d43225