### PR TITLE
Introduce profession_logic package

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ xp.record_action("quest_complete")
 xp.end_session()
 ```
 The modules under `src/` offer simple building blocks that you can integrate into larger systems.
+Utilities for planning professions and trainer routes live under `profession_logic/`.
 
 ## Working with Quests
 

--- a/profession_logic/__init__.py
+++ b/profession_logic/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for profession planning and management."""

--- a/profession_logic/config.py
+++ b/profession_logic/config.py
@@ -1,0 +1,11 @@
+"""Starter configuration toggles for profession logic."""
+
+# Whether individual modules are active
+ENABLE_TRAINER_FINDER = True
+ENABLE_XP_ESTIMATOR = True
+ENABLE_LEVELING_PATH = True
+ENABLE_PROFESSION_MANAGER = True
+
+# Default data locations
+DATA_DIR = "profession_logic/data"
+PROFILE_DIR = "profession_logic/profiles"

--- a/profession_logic/modules/__init__.py
+++ b/profession_logic/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Profession-related helper modules."""

--- a/profession_logic/modules/leveling_path.py
+++ b/profession_logic/modules/leveling_path.py
@@ -1,0 +1,9 @@
+"""Plan out recommended leveling paths."""
+
+from __future__ import annotations
+from typing import List
+
+
+def generate_path(profession: str) -> List[str]:
+    """Return a placeholder sequence of skills."""
+    return []

--- a/profession_logic/modules/profession_manager.py
+++ b/profession_logic/modules/profession_manager.py
@@ -1,0 +1,22 @@
+"""High-level interface for profession progression."""
+
+from __future__ import annotations
+from typing import Dict
+import json
+
+from .. import config
+
+
+class ProfessionManager:
+    """Placeholder manager handling profession profiles."""
+
+    def __init__(self) -> None:
+        self.profiles: Dict[str, Dict] = {}
+
+    def load_profiles(self, path: str = config.PROFILE_DIR + "/master_build_profiles.json") -> None:
+        """Load master build profiles from ``path``."""
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                self.profiles = json.load(fh)
+        except FileNotFoundError:
+            self.profiles = {}

--- a/profession_logic/modules/trainer_finder.py
+++ b/profession_logic/modules/trainer_finder.py
@@ -1,0 +1,15 @@
+"""Locate profession trainers in game data."""
+
+from __future__ import annotations
+from typing import Dict, Optional
+
+
+def find_trainer(profession: str, planet: Optional[str] = None, city: Optional[str] = None) -> Dict:
+    """Return placeholder location details for a trainer."""
+    return {
+        "profession": profession,
+        "planet": planet or "tatooine",
+        "city": city or "mos_eisley",
+        "x": 0,
+        "y": 0,
+    }

--- a/profession_logic/modules/xp_estimator.py
+++ b/profession_logic/modules/xp_estimator.py
@@ -1,0 +1,8 @@
+"""Estimate XP gains for profession activities."""
+
+from __future__ import annotations
+
+
+def estimate_xp_per_hour(profession: str, activity: str) -> float:
+    """Return a placeholder XP/hour value."""
+    return 0.0

--- a/profession_logic/profiles/master_build_profiles.json
+++ b/profession_logic/profiles/master_build_profiles.json
@@ -1,0 +1,6 @@
+{
+    "combat_medic": {
+        "profession": "Combat Medic",
+        "skills": ["Novice Medic", "Field Medicine", "Combat Medicine", "Master Medic"]
+    }
+}

--- a/profession_logic/utils/data_importer.py
+++ b/profession_logic/utils/data_importer.py
@@ -1,0 +1,11 @@
+"""Simple helpers to load profession data files."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: str | Path) -> Any:
+    """Return JSON data from ``path``."""
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)

--- a/profession_logic/utils/logger.py
+++ b/profession_logic/utils/logger.py
@@ -1,0 +1,21 @@
+"""Logging utilities for profession modules."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+DEFAULT_LOG_PATH = Path("logs/profession_logic.log")
+
+
+def get_logger(name: str = "profession_logic", log_path: Path = DEFAULT_LOG_PATH) -> logging.Logger:
+    """Return a configured logger writing to ``log_path``."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.FileHandler(log_path, encoding="utf-8")
+        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger


### PR DESCRIPTION
## Summary
- add new profession_logic package with config toggles
- scaffold modules for trainer finding, XP estimation, leveling paths and profile management
- include basic utilities and sample profiles
- update README with note about profession_logic package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4', requests)*

------
https://chatgpt.com/codex/tasks/task_b_685ceb94824083319d108a905e6d5b02