### PR TITLE
Use android_ms11 for profession data

### DIFF
--- a/android_ms11/data/professions/README.md
+++ b/android_ms11/data/professions/README.md
@@ -1,1 +1,2 @@
-Profession metadata placeholder
+Profession metadata lives here. JSON files are named after the profession,
+e.g. ``medic.json``. These are consumed by the ``progress_tracker`` module.

--- a/android_ms11/data/professions/medic.json
+++ b/android_ms11/data/professions/medic.json
@@ -1,0 +1,13 @@
+{
+    "prerequisites": ["Novice Artisan"],
+    "skill_boxes": [
+        "Novice Medic",
+        "Intermediate Medicine (1,000 Medicine XP)",
+        "Master Doctor (10,000 Medicine XP)"
+    ],
+    "xp_costs": {
+        "Novice Medic": 0,
+        "Intermediate Medicine": 1000,
+        "Master Doctor": 10000
+    }
+}

--- a/modules/professions/progress_tracker.py
+++ b/modules/professions/progress_tracker.py
@@ -5,7 +5,8 @@ from typing import List, Optional, Dict
 
 from modules.learning import xp_estimator
 
-DATA_DIR = os.path.join("data", "parsed", "professions")
+# Default location for profession metadata JSON files
+DATA_DIR = os.path.join("android_ms11", "data", "professions")
 
 
 def _skill_name(text: str) -> str:


### PR DESCRIPTION
## Summary
- store sample profession data under `android_ms11/data/professions`
- update `progress_tracker.DATA_DIR` to the same folder
- document where profession JSON lives

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cecbb29dc8331abe219d82fd2fcda