### PR TITLE
Add test instructions and target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thank you for considering contributing to Android MS11! This project uses `pytest` for automated tests. Before running the tests, make sure all dependencies are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+After installing the requirements you can run the full suite with `pytest` or simply use the provided make target:
+
+```bash
+make test
+```
+
+The `test` target installs the dependencies and then runs `pytest` for you.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test
+
+test:
+	pip install -r requirements.txt
+	pytest

--- a/README.md
+++ b/README.md
@@ -272,3 +272,19 @@ The application writes several logs under the `logs/` directory:
 - `logs/step_journal.log` &ndash; success/failure records from step validation.
 - `logs/session_*.json` &ndash; detailed step traces and summaries for each session.
 - `logs/training_log.txt` &ndash; entries recorded by the trainer navigator.
+
+## Running Tests
+
+Before executing the test suite, install all dependencies listed in
+`requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Once dependencies are installed you can run the tests directly with
+`pytest` or use the convenience target:
+
+```bash
+make test
+```


### PR DESCRIPTION
## Summary
- add CONTRIBUTING notes about installing dependencies and running tests
- provide a Makefile with a `test` target
- document `make test` usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ceef401d88331817f9d4d51f4a6bc