### PR TITLE
Implement XP tracking utilities

### DIFF
--- a/core/xp_estimator.py
+++ b/core/xp_estimator.py
@@ -1,0 +1,59 @@
+"""Simple XP estimator with rolling averages."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict, List
+
+DEFAULT_LOG_PATH = os.path.join("data", "session_logs", "xp_history.json")
+
+
+class XPEstimator:
+    """Track XP gained per action and compute rolling averages."""
+
+    def __init__(self, log_path: str | None = None):
+        if log_path is None:
+            log_path = DEFAULT_LOG_PATH
+        self.log_path = log_path
+        os.makedirs(os.path.dirname(self.log_path), exist_ok=True)
+        self.history: List[Dict] = []
+        self._totals: Dict[str, List[int]] = defaultdict(lambda: [0, 0])  # action -> [total, count]
+        self._load()
+
+    # -----------------------------------------------------
+    def _load(self) -> None:
+        if os.path.exists(self.log_path):
+            try:
+                with open(self.log_path, "r", encoding="utf-8") as fh:
+                    self.history = json.load(fh)
+            except Exception:
+                self.history = []
+        for entry in self.history:
+            action = entry.get("action")
+            xp = int(entry.get("xp", 0))
+            self._totals[action][0] += xp
+            self._totals[action][1] += 1
+
+    def _save(self) -> None:
+        with open(self.log_path, "w", encoding="utf-8") as fh:
+            json.dump(self.history, fh, indent=2)
+
+    # -----------------------------------------------------
+    def log_action(self, action: str, xp: int) -> None:
+        """Record ``xp`` gained for ``action`` and update averages."""
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "action": action,
+            "xp": xp,
+        }
+        self.history.append(entry)
+        self._totals[action][0] += xp
+        self._totals[action][1] += 1
+        self._save()
+
+    def average_xp(self, action: str) -> float:
+        total, count = self._totals.get(action, (0, 0))
+        return total / count if count else 0.0

--- a/src/session_logger.py
+++ b/src/session_logger.py
@@ -1,0 +1,32 @@
+"""Session logging utilities."""
+
+import json
+import os
+from typing import List, Dict
+
+LOG_DIR = os.path.join("data", "session_logs")
+
+
+def _session_path(session_id: str) -> str:
+    os.makedirs(LOG_DIR, exist_ok=True)
+    return os.path.join(LOG_DIR, f"{session_id}.json")
+
+
+def load_session(session_id: str) -> List[Dict]:
+    path = _session_path(session_id)
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def append_entry(session_id: str, entry: Dict) -> str:
+    data = load_session(session_id)
+    data.append(entry)
+    path = _session_path(session_id)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    return path

--- a/tests/test_core_xp_estimator.py
+++ b/tests/test_core_xp_estimator.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.xp_estimator import XPEstimator
+
+
+def test_xp_estimator_rolling_average(tmp_path):
+    log_file = tmp_path / "history.json"
+    est = XPEstimator(log_path=str(log_file))
+    est.log_action("quest", 100)
+    est.log_action("quest", 200)
+
+    assert log_file.exists()
+    data = json.loads(log_file.read_text())
+    assert len(data) == 2
+    assert est.average_xp("quest") == 150
+
+    # Reload and ensure averages persist
+    est2 = XPEstimator(log_path=str(log_file))
+    assert est2.average_xp("quest") == 150

--- a/tests/test_session_logging_with_xp.py
+++ b/tests/test_session_logging_with_xp.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core import xp_estimator
+from core.session_manager import SessionManager
+from src import session_logger
+
+
+def test_session_manager_logs_xp(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(xp_estimator, "DEFAULT_LOG_PATH", str(tmp_path / "xp_history.json"), raising=False)
+    monkeypatch.setattr(session_logger, "LOG_DIR", str(tmp_path))
+
+    session = SessionManager(mode="test")
+    session.set_start_xp(1000)
+    session.set_end_xp(1100)
+    session.end_session()
+
+    history = json.loads((tmp_path / "xp_history.json").read_text())
+    assert history[0]["xp"] == 100
+
+    log_files = list(tmp_path.glob(f"{session.session_id}.json"))
+    assert log_files, "session log not created"
+    log_data = json.loads(log_files[0].read_text())
+    assert log_data[0]["start_xp"] == 1000
+    assert log_data[0]["end_xp"] == 1100
+    assert log_data[0]["xp_gain"] == 100

--- a/utils/session_utils.py
+++ b/utils/session_utils.py
@@ -1,0 +1,54 @@
+"""Helpers for tracking session XP gains."""
+
+from __future__ import annotations
+
+from typing import Optional, Dict
+
+from core.xp_estimator import XPEstimator
+from src import session_logger
+
+
+def track_xp_gain(
+    session_id: str,
+    action: str,
+    start_xp: int,
+    end_xp: Optional[int],
+    estimator: Optional[XPEstimator] = None,
+) -> int:
+    """Determine XP gained and record it.
+
+    Parameters
+    ----------
+    session_id:
+        Unique ID for the active session.
+    action:
+        Descriptive name of the action performed.
+    start_xp:
+        XP value at the start of the action.
+    end_xp:
+        XP value at the end. If ``None`` the estimator is used.
+    estimator:
+        Optional :class:`XPEstimator` instance. If not provided a new one is
+        created using the default log path.
+    """
+    if estimator is None:
+        estimator = XPEstimator()
+
+    if end_xp is not None:
+        xp_gain = max(0, end_xp - start_xp)
+    else:
+        # Fallback to estimator if OCR failed
+        xp_gain = int(estimator.average_xp(action))
+        end_xp = start_xp + xp_gain
+
+    estimator.log_action(action, xp_gain)
+
+    entry: Dict = {
+        "action": action,
+        "start_xp": start_xp,
+        "end_xp": end_xp,
+        "xp_gain": xp_gain,
+        "xp_per_action": estimator.average_xp(action),
+    }
+    session_logger.append_entry(session_id, entry)
+    return xp_gain


### PR DESCRIPTION
## Summary
- implement `XPEstimator` for rolling XP averages
- add `track_xp_gain` helper
- record XP info in `SessionManager`
- add lightweight session logger
- test estimator and session logging behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cf44618e88331aafc68b1fa1ae33f