### PR TITLE
Add runtime profile loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ python src/main.py --mode medic
 python src/main.py --mode grinding
 ```
 
+Runtime profiles stored in `profiles/runtime/` let you bundle these
+settings together. Use the ``--profile`` option to load one:
+
+```bash
+python src/main.py --profile questing
+```
+
 ## Legacy Quest Manager CLI
 Use the legacy quest tool to explore old mission data.
 

--- a/profiles/runtime/crafting.json
+++ b/profiles/runtime/crafting.json
@@ -1,0 +1,9 @@
+{
+  "mode": "crafting",
+  "location": "Corellia",
+  "objectives": [
+    "Build experimental weapons",
+    "Sell finished goods at the bazaar"
+  ],
+  "priority": 3
+}

--- a/profiles/runtime/grinding.json
+++ b/profiles/runtime/grinding.json
@@ -1,0 +1,9 @@
+{
+  "mode": "grinding",
+  "location": "Dantooine",
+  "objectives": [
+    "Farm creatures near the Jedi ruins",
+    "Gather resources for crafting"
+  ],
+  "priority": 2
+}

--- a/profiles/runtime/medic.json
+++ b/profiles/runtime/medic.json
@@ -1,0 +1,9 @@
+{
+  "mode": "medic",
+  "location": "Naboo",
+  "objectives": [
+    "Heal players in Theed",
+    "Restock medical supplies"
+  ],
+  "priority": 1
+}

--- a/profiles/runtime/questing.json
+++ b/profiles/runtime/questing.json
@@ -1,0 +1,9 @@
+{
+  "mode": "questing",
+  "location": "Tatooine",
+  "objectives": [
+    "Complete starter quests around Mos Eisley",
+    "Check in with faction recruiter"
+  ],
+  "priority": 1
+}

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,49 @@
+"""Demo entry point for Android MS11."""
+
+import argparse
+import json
+import os
+from typing import Dict, Any
+
 from core.session_manager import SessionManager
 from src.movement.agent_mover import MovementAgent
 from src.movement.movement_profiles import patrol_route
 from src.training.trainer_visit import visit_trainer
 
+DEFAULT_PROFILE_DIR = os.path.join("profiles", "runtime")
 
-def main():
-    # Initialize new session in your desired mode
-    session = SessionManager(mode="medic")  # Example mode: 'medic', 'crafting', 'questing'
+
+def load_runtime_profile(name: str, directory: str = DEFAULT_PROFILE_DIR) -> Dict[str, Any]:
+    """Return runtime profile data for ``name`` if available."""
+    path = os.path.join(directory, f"{name}.json")
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run a demo session using the selected runtime profile."""
+
+    parser = argparse.ArgumentParser(description="Android MS11 demo")
+    parser.add_argument("--mode", type=str, help="Override session mode")
+    parser.add_argument("--profile", type=str, help="Runtime profile name")
+    args = parser.parse_args(argv)
+
+    profile = load_runtime_profile(args.profile) if args.profile else {}
+
+    mode = args.mode or profile.get("mode", "medic")
+
+    # Initialize new session using the mode from CLI or profile
+    session = SessionManager(mode=mode)
+
+    location = profile.get("location")
+    objectives = profile.get("objectives", [])
+
+    if location:
+        session.add_action(f"Travel to {location}")
+    for obj in objectives:
+        session.add_action(obj)
 
     # Simulated: retrieve credits before and after
     session.set_start_credits(2000)

--- a/tests/test_runtime_profile.py
+++ b/tests/test_runtime_profile.py
@@ -1,0 +1,18 @@
+import json
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import src.main as main
+
+
+def test_load_runtime_profile(tmp_path, monkeypatch):
+    data = {"mode": "questing", "location": "Test", "objectives": ["A"], "priority": 1}
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(data))
+    reload(main)
+    prof = main.load_runtime_profile("demo", directory=str(tmp_path))
+    assert prof == data
+


### PR DESCRIPTION
## Summary
- add example JSON runtime profiles for different activities
- load profile data in `src/main.py`
- document `--profile` option in README
- test the runtime profile loading

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cf6d201c88331a5860cac11be605b