### PR TITLE
Add import guards for requests and bs4

### DIFF
--- a/scripts/importers/profession_importer.py
+++ b/scripts/importers/profession_importer.py
@@ -1,8 +1,17 @@
 import os
 import json
 import re
-import requests
-from bs4 import BeautifulSoup
+try:
+    import requests
+except ImportError as exc:
+    print("Error: the 'requests' package is required. Install it with 'pip install requests'.")
+    raise SystemExit(1) from exc
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError as exc:
+    print("Error: the 'bs4' package (BeautifulSoup) is required. Install it with 'pip install beautifulsoup4'.")
+    raise SystemExit(1) from exc
 
 BASE_URL = "https://swgr.org/wiki/"
 OUTPUT_DIR = os.path.join("android_ms11", "data", "professions")

--- a/utils/wiki_scraper.py
+++ b/utils/wiki_scraper.py
@@ -1,5 +1,14 @@
-import requests
-from bs4 import BeautifulSoup
+try:
+    import requests
+except ImportError as exc:
+    print("Error: the 'requests' package is required. Install it with 'pip install requests'.")
+    raise SystemExit(1) from exc
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError as exc:
+    print("Error: the 'bs4' package (BeautifulSoup) is required. Install it with 'pip install beautifulsoup4'.")
+    raise SystemExit(1) from exc
 
 
 class WikiScraper:


### PR DESCRIPTION
## Summary
- handle missing `requests`/`bs4` dependencies in `profession_importer` and `wiki_scraper`
- exit with helpful instructions when imports fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d025748608331aded8dc85452d3cc