### PR TITLE
Add travel_to_trainer helper

### DIFF
--- a/modules/travel/__init__.py
+++ b/modules/travel/__init__.py
@@ -1,0 +1,5 @@
+"""Travel helpers package."""
+
+from .trainer_travel import travel_to_trainer
+
+__all__ = ["travel_to_trainer"]

--- a/modules/travel/trainer_travel.py
+++ b/modules/travel/trainer_travel.py
@@ -1,0 +1,66 @@
+"""High level travel helper for visiting profession trainers."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from scripts.travel import shuttle
+from src.movement.movement_profiles import walk_to_coords
+
+
+DEFAULT_START_CITY = "mos_eisley"
+DEFAULT_START_PLANET = "tatooine"
+
+
+def travel_to_trainer(profession: str, trainer_data: Dict[str, dict], agent=None):
+    """Travel via shuttle to the trainer for ``profession``.
+
+    Parameters
+    ----------
+    profession:
+        Name of the profession to look up.
+    trainer_data:
+        Mapping of profession information typically returned by
+        ``utils.load_trainers.load_trainers``.
+    agent:
+        Optional movement agent passed to the underlying navigation helpers.
+
+    Returns
+    -------
+    object
+        Whatever value :func:`scripts.travel.shuttle.navigate_to` returns.
+    """
+    prof_entry = trainer_data.get(profession)
+    if not prof_entry:
+        print(f"[Travel] No trainer data for {profession}")
+        return None
+
+    # Pick the first available planet/city entry
+    planet, cities = next(iter(prof_entry.items()))
+    city, entry = next(iter(cities.items()))
+    dest_x = entry.get("x", 0)
+    dest_y = entry.get("y", 0)
+
+    # Plan the shuttle route so we can log the chosen path
+    route = shuttle.plan_route(
+        DEFAULT_START_CITY,
+        city,
+        start_planet=DEFAULT_START_PLANET,
+        dest_planet=planet,
+    )
+    if route:
+        path = " -> ".join(stop["city"] for stop in route)
+        print(f"[Travel] Planned shuttle route: {path}")
+    else:
+        print("[Travel] No shuttle route found.")
+
+    result = shuttle.navigate_to(
+        city,
+        agent=agent,
+        start_city=DEFAULT_START_CITY,
+        start_planet=DEFAULT_START_PLANET,
+        dest_planet=planet,
+    )
+
+    walk_to_coords(agent, dest_x, dest_y)
+    return result

--- a/tests/test_travel_to_trainer.py
+++ b/tests/test_travel_to_trainer.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.travel import trainer_travel
+from scripts.travel import shuttle
+from src.movement import movement_profiles
+
+
+def test_travel_to_trainer_invokes_navigation(monkeypatch):
+    calls = []
+
+    def fake_nav(city, agent, start_city="mos_eisley", start_planet="tatooine", dest_planet=None, shuttle_file=None):
+        calls.append(("nav", city, start_city, start_planet, dest_planet))
+        return "NAV"
+
+    def fake_walk(agent, x, y):
+        calls.append(("walk", x, y))
+
+    monkeypatch.setattr(shuttle, "navigate_to", fake_nav)
+    monkeypatch.setattr(trainer_travel, "walk_to_coords", fake_walk)
+    monkeypatch.setattr(shuttle, "plan_route", lambda *a, **k: [{"city": "mos_eisley"}, {"city": "coronet"}])
+
+    data = {"artisan": {"tatooine": {"mos_eisley": {"name": "Trainer", "x": 1, "y": 2}}}}
+    result = trainer_travel.travel_to_trainer("artisan", data, agent="A")
+
+    assert result == "NAV"
+    assert calls == [
+        ("nav", "mos_eisley", "mos_eisley", "tatooine", "tatooine"),
+        ("walk", 1, 2),
+    ]
+
+
+def test_travel_to_trainer_logs_route(monkeypatch, capsys):
+    monkeypatch.setattr(shuttle, "navigate_to", lambda *a, **k: None)
+    monkeypatch.setattr(trainer_travel, "walk_to_coords", lambda *a, **k: None)
+    monkeypatch.setattr(shuttle, "plan_route", lambda *a, **k: [{"city": "mos_eisley"}, {"city": "anchorhead"}])
+
+    data = {"brawler": {"tatooine": {"anchorhead": {"name": "Brawl", "x": 5, "y": 6}}}}
+    trainer_travel.travel_to_trainer("brawler", data, agent="A")
+
+    out = capsys.readouterr().out
+    assert "mos_eisley -> anchorhead" in out


### PR DESCRIPTION
## Summary
- create `trainer_travel` module with `travel_to_trainer` helper
- expose helper in `modules.travel` package
- add tests for traveling to trainers via shuttle routing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685d8c2204b08331b65047e297636b91