### PR TITLE
Implement skill training check

### DIFF
--- a/tests/test_check_and_train_skills.py
+++ b/tests/test_check_and_train_skills.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import src.main as main
+
+
+def test_check_and_train_triggers_travel(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr(main, "load_trainers", lambda: {
+        "artisan": {"tatooine": {"mos_eisley": {"name": "Trainer", "x": 1, "y": 2}}}
+    })
+    monkeypatch.setattr(
+        main, "get_trainable_skills", lambda skills, tree: [("artisan", 1)]
+    )
+    def fake_travel(prof, data, agent=None):
+        calls["args"] = (prof, data, agent)
+    monkeypatch.setattr(main, "travel_to_trainer", fake_travel)
+
+    main.check_and_train_skills("AGENT", {}, {})
+
+    assert calls["args"][0] == "artisan"
+    assert calls["args"][2] == "AGENT"
+


### PR DESCRIPTION
## Summary
- add `check_and_train_skills` helper and call it in `main`
- unit test verifies trainer travel is triggered when skills are available

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d9533ca70833184288765cdf9ffdd