### PR TITLE
Add JSON logging for trainer events

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -5,7 +5,7 @@
 - **Mode runner**: `main.py` and `runner.py` provide CLI entry points to launch different automation modes.
 - **Quest database**: `src/db` holds SQLite schema, quest insertion helpers, and utilities for viewing quests.
 - **Training helpers**: `trainer_data_loader.py`, `trainer_visit.py`, and the `find_trainer.py` CLI locate NPC trainers and automate visits.
-- **Trainer navigator**: `scripts/logic/trainer_navigator.py` lists nearby trainers and records visits in `logs/training_log.txt` using data from `data/trainers.yaml`.
+- **Trainer navigator**: `scripts/logic/trainer_navigator.py` lists nearby trainers and records visits in `logs/training_log.txt`. It can also write JSON lines to `logs/training.json` using data from `data/trainers.yaml`.
 
 ## Modules Needing Work
 - `quest_selector.py` – loads legacy quests and DB entries with filtering support; still needs scoring improvements.

--- a/scripts/logic/trainer_navigator.py
+++ b/scripts/logic/trainer_navigator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import math
 import os
+import json
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -19,8 +20,9 @@ from utils.get_trainer_location import get_trainer_location
 from src.training.trainer_visit import visit_trainer
 from src.utils.logger import log_event
 
-# Default log file under the project's ``logs`` directory.
+# Default log files under the project's ``logs`` directory.
 DEFAULT_LOG_PATH = os.path.join("logs", "training_log.txt")
+DEFAULT_JSON_PATH = os.path.join("logs", "training.json")
 
 # Type aliases for clarity
 Coords = Tuple[int, int]
@@ -78,8 +80,14 @@ def log_training_event(
     trainer_name: str,
     distance: float,
     log_path: str = DEFAULT_LOG_PATH,
+    *,
+    json_path: Optional[str] = None,
 ) -> None:
-    """Append a training event to ``log_path`` with a timestamp."""
+    """Append a training event to ``log_path`` with a timestamp.
+
+    If ``json_path`` is provided, the event is also appended as JSON to that
+    file (one object per line).
+    """
     if os.path.abspath(log_path) == os.path.abspath(DEFAULT_LOG_PATH):
         # Ensure the default ``logs`` directory exists when writing the
         # standard ``training_log.txt`` file.
@@ -92,6 +100,22 @@ def log_training_event(
     message = f"{timestamp} - Trained with {trainer_name} ({profession}) at distance {distance:.1f}\n"
     with open(log_path, "a", encoding="utf-8") as fh:
         fh.write(message)
+
+    if json_path:
+        if os.path.abspath(json_path) == os.path.abspath(DEFAULT_JSON_PATH):
+            os.makedirs("logs", exist_ok=True)
+        else:
+            dir_name = os.path.dirname(json_path)
+            if dir_name:
+                os.makedirs(dir_name, exist_ok=True)
+        entry = {
+            "timestamp": timestamp,
+            "profession": profession,
+            "trainer": trainer_name,
+            "distance": distance,
+        }
+        with open(json_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
 
 
 def navigate_to_trainer(

--- a/tests/test_trainer_navigator.py
+++ b/tests/test_trainer_navigator.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 from importlib import reload
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -50,6 +51,21 @@ def test_log_training_event(tmp_path):
     assert log_file.exists()
     content = log_file.read_text()
     assert "Artisan Trainer" in content
+
+
+def test_log_training_event_json(tmp_path):
+    log_file = tmp_path / "subdir" / "log.txt"
+    json_file = tmp_path / "subdir" / "training.json"
+    tn.log_training_event(
+        "artisan",
+        "Artisan Trainer",
+        5.0,
+        log_path=str(log_file),
+        json_path=str(json_file),
+    )
+    assert json_file.exists()
+    data = [json.loads(line) for line in json_file.read_text().splitlines()]
+    assert data[0]["trainer"] == "Artisan Trainer"
 
 
 def test_find_nearby_trainers_sorted(monkeypatch):


### PR DESCRIPTION
## Summary
- extend `trainer_navigator.log_training_event` with an optional `json_path` parameter
- write JSON lines when a path is provided
- document the new log file in `NOTES.md`
- add tests for JSON logging

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_685d98f8c5588331a12e1d8f453fe1c5