### PR TITLE
Add DISCORD_TOKEN env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Example configuration:
   "relay_user_id": 0
 }
 ```
+If ``discord_token`` is empty in the JSON file, the bot will look for a
+``DISCORD_TOKEN`` environment variable instead. This lets you keep the token out
+of the repo when deploying or running locally.
 
 `relay_mode` controls how whispers are delivered:
 

--- a/discord/bot.py
+++ b/discord/bot.py
@@ -1,6 +1,7 @@
 """Entry point for launching the Discord relay bot."""
 
 import json
+import os
 from discord.ext import commands
 
 import discord_relay
@@ -9,7 +10,12 @@ import discord_relay
 def load_config(path: str = "config/discord_config.json") -> dict:
     """Load Discord bot configuration from ``path``."""
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    if not cfg.get("discord_token"):
+        env_token = os.getenv("DISCORD_TOKEN")
+        if env_token:
+            cfg["discord_token"] = env_token
+    return cfg
 
 
 def start_bot() -> None:

--- a/main_discord_bot.py
+++ b/main_discord_bot.py
@@ -1,11 +1,17 @@
 from discord.ext import commands
 import json
+import os
 import discord_relay
 
 
 def load_config(path: str = "config/discord_config.json") -> dict:
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    if not cfg.get("discord_token"):
+        env_token = os.getenv("DISCORD_TOKEN")
+        if env_token:
+            cfg["discord_token"] = env_token
+    return cfg
 
 
 def main() -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -76,6 +76,10 @@ def main(argv: list[str] | None = None) -> None:
     bot = None
     if relay_enabled and commands and discord_relay:
         discord_cfg = load_json(DISCORD_CONFIG_PATH)
+        if not discord_cfg.get("discord_token"):
+            env_token = os.getenv("DISCORD_TOKEN")
+            if env_token:
+                discord_cfg["discord_token"] = env_token
         bot = commands.Bot(command_prefix="!")
         discord_relay.setup(bot, discord_cfg)
         threading.Thread(


### PR DESCRIPTION
## Summary
- support reading `DISCORD_TOKEN` from the environment in bot helpers
- document the variable in README

## Testing
- `pytest -q` *(fails: SystemExit from profession_importer)*

------
https://chatgpt.com/codex/tasks/task_b_685dbbde8f2883319de2e97fbfedab36