### PR TITLE
Add logs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+logs/
 
 # Flask stuff:
 instance/

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ The application writes several logs under the `logs/` directory:
 - `logs/session_*.json` &ndash; detailed step traces and summaries for each session.
 - `logs/training_log.txt` &ndash; entries recorded by the trainer navigator.
 
+Running the test suite also writes logs to this directory.
+
 ## Running Tests
 
 Before executing the test suite, install all dependencies listed in


### PR DESCRIPTION
## Summary
- ignore the `logs/` directory so test artifacts don't get committed
- note that running tests creates log files

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_685dd366357c83318f5d58c2c3343a13