### PR TITLE
Add Discord DM bot utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Run the bot directly:
 python relaybot/bot.py
 ```
 
+To launch a bot that only uses direct messages, run:
+
+```bash
+python discord_dm_bot.py
+```
+
 Or start the demo with relay enabled:
 
 ```bash

--- a/discord_dm_bot.py
+++ b/discord_dm_bot.py
@@ -1,0 +1,39 @@
+"""Standalone DM-ready Discord relay bot launcher."""
+
+import json
+import os
+
+import discord
+from discord.ext import commands
+
+import discord_relay
+
+
+CONFIG_PATH = "config/discord_config.json"
+
+
+def load_config(path: str = CONFIG_PATH) -> dict:
+    """Load Discord configuration from ``path`` and env vars."""
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    if not cfg.get("discord_token"):
+        env_token = os.getenv("DISCORD_TOKEN")
+        if env_token:
+            cfg["discord_token"] = env_token
+    return cfg
+
+
+def main() -> None:
+    """Create the bot with DM intents and run it."""
+    config = load_config()
+    intents = discord.Intents.default()
+    intents.dm_messages = True
+    intents.message_content = True
+
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    discord_relay.setup(bot, config)
+    bot.run(config["discord_token"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `discord_dm_bot.py` for running the relay bot using DM intents
- document new script in README

## Testing
- `pip install -v -r requirements-test.txt`
- `pip install -q beautifulsoup4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ddcf2b6e48331b6b7c3e66692ec97