### PR TITLE
Validate relay_user_id in DiscordRelay

### DIFF
--- a/discord_relay.py
+++ b/discord_relay.py
@@ -18,6 +18,9 @@ class DiscordRelay(commands.Cog):
         self.user_id = config.get("relay_user_id")
         self.mode = config.get("relay_mode", "notify")
 
+        if not self.user_id:
+            raise ValueError("relay_user_id must be configured for DiscordRelay")
+
     @commands.Cog.listener()
     async def on_ready(self) -> None:
         print(f"[DiscordRelay] Connected as {self.bot.user}")

--- a/tests/test_discord_relay.py
+++ b/tests/test_discord_relay.py
@@ -2,6 +2,7 @@ import os
 import sys
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import discord_relay
@@ -75,3 +76,10 @@ def test_on_message_extracts_manual_reply(monkeypatch):
     asyncio.run(relay.on_message(msg))
 
     assert relay.config["reply_queue"] == [("bob", "hi there")]
+
+
+def test_init_requires_user_id():
+    bot = MagicMock()
+    config = {"relay_mode": "notify", "relay_channel_id": 42}
+    with pytest.raises(ValueError):
+        DiscordRelay(bot, config)


### PR DESCRIPTION
## Summary
- enforce `relay_user_id` presence when initializing `DiscordRelay`
- test that initialization fails without a user id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685de493a6b083319d3d7a7bad11b54e