### PR TITLE
Add DM relay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,9 @@ Example configuration:
 ```json
 {
   "discord_token": "YOUR_BOT_TOKEN",
-  "relay_channel_id": 1234567890,
   "relay_mode": "manual",
-  "reply_queue": [],
-  "relay_user_id": 0
+  "target_user_id": 0,
+  "reply_queue": []
 }
 ```
 If ``discord_token`` is empty in the JSON file, the bot will look for a
@@ -171,8 +170,7 @@ of the repo when deploying or running locally.
 - `manual` – wait for manual replies via DM.
 - `auto` – auto-reply using placeholder AI logic.
 
-Set `relay_user_id` (or `dm_user_id`) to deliver messages via DM; otherwise the
-configured channel is used.
+Set `target_user_id` to specify the DM recipient.
 
 Run the bot directly:
 

--- a/config/discord_config.json
+++ b/config/discord_config.json
@@ -1,7 +1,6 @@
 {
   "discord_token": "YOUR_BOT_TOKEN",
-  "relay_channel_id": 0,
-  "relay_mode": "manual",
-  "reply_queue": [],
-  "relay_user_id": 0
+  "relay_mode": "notify",
+  "target_user_id": 0,
+  "reply_queue": []
 }

--- a/discord_relay.py
+++ b/discord_relay.py
@@ -14,35 +14,28 @@ class DiscordRelay(commands.Cog):
     def __init__(self, bot: commands.Bot, config: dict) -> None:
         self.bot = bot
         self.config = config
-        self.channel_id = config.get("relay_channel_id")
-        self.user_id = config.get("relay_user_id")
+        self.target_user_id = config.get("target_user_id")
         self.mode = config.get("relay_mode", "notify")
 
-        if not self.user_id:
-            raise ValueError("relay_user_id must be configured for DiscordRelay")
+        if not self.target_user_id:
+            raise ValueError("target_user_id must be configured for DiscordRelay")
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
         print(f"[DiscordRelay] Connected as {self.bot.user}")
 
     async def safe_send_user(self, message: str) -> None:
-        """Send a DM to the configured user with fallback to the relay channel."""
+        """Send a DM to the configured user."""
         try:
-            user = await self.bot.fetch_user(self.user_id)
+            user = await self.bot.fetch_user(self.target_user_id)
             await user.send(message)
-        except discord.Forbidden:
-            channel = self.bot.get_channel(self.channel_id)
-            if channel:
-                await channel.send(
-                    f"\u274c Couldn't DM {user.name}. Here's the message:\n{message}"
-                )
         except discord.HTTPException as e:
             print(f"[Error] Failed to send DM: {e}")
 
     async def relay_to_discord(self, sender: str, message: str) -> str | None:
         """Send a whisper to Discord based on the active mode."""
         try:
-            user = await self.bot.fetch_user(self.user_id)
+            user = await self.bot.fetch_user(self.target_user_id)
         except Exception as e:
             print(f"[Error] Could not fetch user: {e}")
             return None
@@ -74,7 +67,7 @@ class DiscordRelay(commands.Cog):
         if (
             self.mode == "manual"
             and isinstance(message.channel, discord.DMChannel)
-            and message.author.id == self.user_id
+            and message.author.id == self.target_user_id
             and message.content.startswith("@")
         ):
             parts = message.content[1:].split(" ", 1)

--- a/main_discord_bot.py
+++ b/main_discord_bot.py
@@ -1,11 +1,24 @@
-"""Compatibility wrapper for launching the Discord relay bot."""
+"""Simple entry point for running the Discord relay bot."""
 
-from relaybot.bot import start_bot
+import json
+from discord.ext import commands
+
+from discord_relay import DiscordRelay
 
 
 def main() -> None:
-    """Launch the Discord relay bot using the shared entry point."""
-    start_bot()
+    """Load configuration and launch the bot."""
+    with open("config/discord_config.json", "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    bot = commands.Bot(command_prefix="!")
+    bot.add_cog(DiscordRelay(bot, config))
+
+    @bot.event
+    async def on_ready() -> None:
+        print(f"[Bot] Logged in as {bot.user}")
+
+    bot.run(config["discord_token"])
 
 
 if __name__ == "__main__":

--- a/tests/test_discord_relay.py
+++ b/tests/test_discord_relay.py
@@ -18,7 +18,7 @@ def test_generate_ai_reply_basic():
 def test_relay_notify_mode():
     bot = MagicMock()
     bot.fetch_user = AsyncMock(return_value=MagicMock())
-    config = {'relay_mode': 'notify', 'relay_user_id': 1, 'relay_channel_id': 42}
+    config = {'relay_mode': 'notify', 'target_user_id': 1}
     relay = DiscordRelay(bot, config)
     relay.safe_send_user = AsyncMock()
 
@@ -32,7 +32,7 @@ def test_relay_notify_mode():
 def test_relay_auto_mode_generates_reply():
     bot = MagicMock()
     bot.fetch_user = AsyncMock(return_value=MagicMock())
-    config = {'relay_mode': 'auto', 'relay_user_id': 1, 'relay_channel_id': 42}
+    config = {'relay_mode': 'auto', 'target_user_id': 1}
     relay = DiscordRelay(bot, config)
     relay.safe_send_user = AsyncMock()
 
@@ -48,7 +48,7 @@ def test_relay_auto_mode_generates_reply():
 def test_relay_fetch_user_error():
     bot = MagicMock()
     bot.fetch_user = AsyncMock(side_effect=Exception('fail'))
-    config = {'relay_mode': 'notify', 'relay_user_id': 1, 'relay_channel_id': 42}
+    config = {'relay_mode': 'notify', 'target_user_id': 1}
     relay = DiscordRelay(bot, config)
     relay.safe_send_user = AsyncMock()
 
@@ -60,7 +60,7 @@ def test_relay_fetch_user_error():
 
 def test_on_message_extracts_manual_reply(monkeypatch):
     bot = MagicMock()
-    config = {"relay_mode": "manual", "relay_user_id": 99, "relay_channel_id": 42}
+    config = {"relay_mode": "manual", "target_user_id": 99}
     relay = DiscordRelay(bot, config)
 
     class DummyDM:
@@ -80,6 +80,6 @@ def test_on_message_extracts_manual_reply(monkeypatch):
 
 def test_init_requires_user_id():
     bot = MagicMock()
-    config = {"relay_mode": "notify", "relay_channel_id": 42}
+    config = {"relay_mode": "notify"}
     with pytest.raises(ValueError):
         DiscordRelay(bot, config)


### PR DESCRIPTION
## Summary
- send Discord whispers as DMs to `target_user_id`
- update default config to use `target_user_id`
- simplify main entry point for DM relay bot
- document new config fields
- adjust unit tests

## Testing
- `pip install -r requirements-test.txt`
- `pip install beautifulsoup4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ded501f848331ad437f7aab22f07b