### PR TITLE
Improve test setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,13 @@
 # Contributing
 
-Thank you for considering contributing to Android MS11! This project uses `pytest` for automated tests. Before running the tests, make sure all dependencies are installed:
+Thank you for considering contributing to Android MS11! This project uses `pytest` for automated tests.
+Before running the tests, make sure all dependencies are installed. The easiest way is to run:
 
 ```bash
-pip install -r requirements.txt
+./scripts/setup_test_env.sh
 ```
+
+This will install both `requirements.txt` and `requirements-test.txt`. You can also perform these steps manually if preferred.
 
 After installing the requirements you can run the full suite with `pytest` or simply use the provided make target:
 

--- a/README.md
+++ b/README.md
@@ -344,8 +344,15 @@ Running the test suite also writes logs to this directory.
 
 ## Running Tests
 
-Before executing the test suite, install all dependencies listed in
-`requirements.txt`:
+Before executing the test suite, ensure all dependencies are installed.
+You can run the helper script below or manually install the packages.
+
+```bash
+./scripts/setup_test_env.sh
+```
+
+If you prefer to install manually, install the system packages and
+then the Python requirements:
 
 ```bash
 sudo apt-get install tesseract-ocr libtesseract-dev

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,7 @@
 # Additional dependencies required when running the test suite
-requests>=2.0
-discord.py
+# Install these alongside `requirements.txt` before invoking pytest
+#   pip install -r requirements.txt -r requirements-test.txt
+# or run `scripts/setup_test_env.sh`
+
+requests>=2.0   # used by profession_importer tests
+discord.py      # used by Discord relay tests

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Install system and Python dependencies required for running the test suite.
+set -e
+
+# Install system packages needed for OCR tests
+sudo apt-get update -y
+sudo apt-get install -y tesseract-ocr libtesseract-dev
+
+# Install Python packages
+pip install -r requirements.txt -r requirements-test.txt


### PR DESCRIPTION
## Summary
- clarify test suite setup in README
- update CONTRIBUTING with helper script instructions
- expand comments in `requirements-test.txt`
- add helper script `scripts/setup_test_env.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e393024a08331849b4b438d2ddca8