### PR TITLE
Document license for wiki-derived data

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,4 +10,10 @@ repository-code: "https://github.com/R21Digital/Project-MorningStar"
 license: "MIT"
 
 # Data Acknowledgment
-# Quest and item data derived from swgr.org/wiki, hosted on Fandom under the Creative Commons Attribution-ShareAlike 3.0 license. See data/metadata_index.json for details on data sources.
+# Quest and item data derived from swgr.org/wiki, hosted on Fandom under the
+# Creative Commons Attribution-ShareAlike 3.0 license (CC-BY-SA 3.0).
+# The HTML snapshot at `data/raw/legacy.html` and other text assets under
+# `data/wiki_raw/` are scraped from the SWG Wiki. These files are used solely
+# to provide quest metadata and are redistributed under the same CC-BY-SA
+# terms. See https://www.fandom.com/licensing and
+# `data/metadata_index.json` for more details on the sources.

--- a/README.md
+++ b/README.md
@@ -367,5 +367,14 @@ Once dependencies are installed you can run the tests directly with
 make test
 ```
 
+## Wiki Content and Licensing
+
+The file `data/raw/legacy.html` and the JSON files under `data/wiki_raw/` were
+exported from the SWG Wiki hosted on Fandom. This material is licensed under
+the Creative Commons Attribution-ShareAlike 3.0 license (CC-BY-SA 3.0). See
+<https://www.fandom.com/licensing> for the official licensing terms. The
+project uses these extracts solely to look up quest and item information and
+includes references back to the original pages via `data/metadata_index.json`.
+
 ## Disclaimer
 Android MS11 is an unofficial project, not affiliated with SWGR or LucasArts, and must be used in accordance with the game's terms of service.


### PR DESCRIPTION
## Summary
- call out wiki assets are CC-BY-SA in `CITATION.cff`
- detail wiki content licensing in README

## Testing
- `pytest -q` *(fails: requests not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685e3c21ae08833185c7748e8e3cde8f