### PR TITLE
Refactor quest step handling with action router

### DIFF
--- a/quest_engine.py
+++ b/quest_engine.py
@@ -1,23 +1,19 @@
-from utils.movement_manager import travel_to
-from utils.npc_handler import interact_with_npc
-from utils.combat_handler import engage_targets
+"""Simple quest step executor."""
+
+from src.execution.action_router import get_handler
 
 
 def handle_quest_step(step: dict) -> bool:
-    """Route a quest step to the appropriate handler."""
-    action = step.get("action")
-    coords = step.get("coords", (0, 0))
-    zone = step.get("zone", "Unknown")
+    """Execute a quest step using the action router."""
+    step_type = step.get("type")
+    data = step.get("data", {})
 
-    print(f"[ENGINE] Handling action: {action} at {coords}")
-    travel_to(zone, coords)
+    print(f"[ENGINE] Handling step type: {step_type} with data: {data}")
 
-    if action == "talk":
-        return interact_with_npc(step.get("npc", "Unknown"))
-    if action == "kill":
-        target = step.get("target", "Unknown")
-        count = step.get("count", 1)
-        return engage_targets(target, count)
+    handler = get_handler(step_type)
+    if not handler:
+        print(f"[!] Unknown action type: {step_type}")
+        return False
 
-    print(f"[!] Unknown action type: {action}")
-    return False
+    handler(**data)
+    return True

--- a/src/execution/action_router.py
+++ b/src/execution/action_router.py
@@ -1,0 +1,16 @@
+"""Dispatch low-level action handlers."""
+
+from utils.movement_manager import travel_to
+from utils.npc_handler import interact_with_npc
+from utils.combat_handler import engage_targets
+
+ACTION_ROUTER = {
+    "combat": engage_targets,
+    "move": travel_to,
+    "npc": interact_with_npc,
+}
+
+
+def get_handler(action_type: str):
+    """Return the handler function for ``action_type`` or ``None``."""
+    return ACTION_ROUTER.get(action_type)

--- a/src/modes/questing.py
+++ b/src/modes/questing.py
@@ -9,13 +9,28 @@ def load_legacy_quest():
 
 def run_questing_mode(character: str) -> None:
     print(f"[QUESTING] Starting Legacy Quest mode for {character}")
-    steps = load_legacy_quest()
+    raw_steps = load_legacy_quest()
 
-    for step in steps:
-        print(f"\n[STEP {step['id']}] {step['title']}")
+    for raw in raw_steps:
+        print(f"\n[STEP {raw['id']}] {raw['title']}")
+        # movement step to coordinates
+        move = {"type": "move", "data": {"zone": raw["zone"], "coords": raw["coords"]}}
+        handle_quest_step(move)
+
+        if raw["action"] == "talk":
+            step = {"type": "npc", "data": {"npc_name": raw["npc"]}}
+        elif raw["action"] == "kill":
+            step = {
+                "type": "combat",
+                "data": {"target_name": raw["target"], "count": raw.get("count", 1)},
+            }
+        else:
+            print(f"[!] Unknown legacy action: {raw['action']}")
+            continue
+
         success = handle_quest_step(step)
         if not success:
-            print(f"[!] Failed to complete step: {step['id']}")
+            print(f"[!] Failed to complete step: {raw['id']}")
             break
     else:
         print("[\u2713] All Legacy steps complete.")


### PR DESCRIPTION
## Summary
- add `action_router` that maps simple action types to handler functions
- refactor `quest_engine.handle_quest_step` to use the router and new step format
- convert questing mode to emit `{"type", "data"}` style steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e48179fac8331b92b8aa42a9a3212