### PR TITLE
Add quest runner CLI

### DIFF
--- a/run_quest.py
+++ b/run_quest.py
@@ -1,0 +1,40 @@
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, os.path.abspath("."))
+
+from src.execution.quest_executor import QuestExecutor
+
+
+def load_steps(path: str) -> list[dict]:
+    """Return quest steps loaded from JSON or YAML ``path``."""
+    with open(path, "r", encoding="utf-8") as fh:
+        if path.lower().endswith((".yaml", ".yml")):
+            data: Any = yaml.safe_load(fh)
+        else:
+            data = json.load(fh)
+    if isinstance(data, dict):
+        return data.get("steps", [])
+    return data if isinstance(data, list) else []
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run a quest file")
+    parser.add_argument("quest_file", help="Path to quest JSON/YAML file")
+    args = parser.parse_args(argv)
+
+    steps = load_steps(args.quest_file)
+    print(f"[RUN QUEST] Loaded {len(steps)} steps from {args.quest_file}")
+
+    executor = QuestExecutor(args.quest_file)
+    executor.steps = steps
+    executor.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_quest.py` to run quest files from JSON or YAML
- parse CLI argument to load steps and execute via `QuestExecutor`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e4b66bed883319c000b63a552388f