### PR TITLE
Add profession skill trainer integration

### DIFF
--- a/config/profession_config.py
+++ b/config/profession_config.py
@@ -1,0 +1,21 @@
+"""Default profession skill requirements and trainer locations."""
+
+REQUIRED_SKILLS = {
+    "artisan": ["Novice Artisan"],
+    "marksman": ["Novice Marksman"],
+}
+
+TRAINER_BY_PROFESSION = {
+    "artisan": {
+        "planet": "tatooine",
+        "city": "mos_eisley",
+        "coords": [3432, -4795],
+        "name": "Artisan Trainer",
+    },
+    "marksman": {
+        "planet": "corellia",
+        "city": "coronet",
+        "coords": [-150, 60],
+        "name": "Marksman Trainer",
+    },
+}

--- a/core/profession_manager.py
+++ b/core/profession_manager.py
@@ -1,0 +1,33 @@
+"""Utilities for managing profession skill training."""
+
+from __future__ import annotations
+from typing import List, Dict
+
+from utils.movement_manager import travel_to
+from utils.npc_handler import interact_with_trainer
+from utils.ocr_scanner import scan_skills_ui
+from config.profession_config import REQUIRED_SKILLS, TRAINER_BY_PROFESSION
+
+
+class ProfessionManager:
+    """Manage profession progression and training."""
+
+    def __init__(self, trainer_map: Dict[str, Dict] | None = None) -> None:
+        self.trainer_map = trainer_map or TRAINER_BY_PROFESSION
+
+    # --------------------------------------------------
+    def train_missing_skills(self) -> None:
+        """Check learned skills and train at the appropriate trainer."""
+        learned = [s.lower() for s in scan_skills_ui()]
+        for profession, skills in REQUIRED_SKILLS.items():
+            missing = [s for s in skills if s.lower() not in learned]
+            if not missing:
+                continue
+            trainer = self.trainer_map.get(profession)
+            if not trainer:
+                continue
+            zone = trainer["planet"]
+            coords = trainer["coords"]
+            travel_to(zone, coords)
+            interact_with_trainer(trainer["name"])
+

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,7 @@
+"""Test environment initialization importing optional dependencies."""
+
+# Ensure BeautifulSoup is available for tests that rely on it.
+try:
+    import bs4  # noqa: F401
+except Exception:
+    pass

--- a/tests/test_profession_manager.py
+++ b/tests/test_profession_manager.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import bs4
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.profession_manager import ProfessionManager
+import utils.ocr_scanner as ocr_scanner
+
+
+def test_train_missing_skills_travels(monkeypatch):
+    pm = ProfessionManager()
+    calls = {}
+
+    monkeypatch.setattr("core.profession_manager.scan_skills_ui", lambda: [])
+
+    def fake_travel(zone, coords):
+        calls.setdefault("travel", []).append((zone, coords))
+
+    def fake_interact(name):
+        calls.setdefault("interact", []).append(name)
+        return True
+
+    monkeypatch.setattr("core.profession_manager.travel_to", fake_travel)
+    monkeypatch.setattr("core.profession_manager.interact_with_trainer", fake_interact)
+
+    pm.train_missing_skills()
+
+    assert calls["travel"][0][0] == "tatooine"
+    assert calls["interact"][0] == "Artisan Trainer"
+
+
+def test_train_missing_skills_no_action(monkeypatch):
+    pm = ProfessionManager()
+    monkeypatch.setattr(
+        "core.profession_manager.scan_skills_ui",
+        lambda: ["Novice Artisan", "Novice Marksman"],
+    )
+
+    called = False
+
+    def fake_travel(*a, **k):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("core.profession_manager.travel_to", fake_travel)
+    monkeypatch.setattr("core.profession_manager.interact_with_trainer", lambda n: True)
+
+    pm.train_missing_skills()
+
+    assert not called

--- a/utils/npc_handler.py
+++ b/utils/npc_handler.py
@@ -7,3 +7,9 @@ def interact_with_npc(npc_name: str) -> bool:
     # Simulated result of interaction
     # Future: use OCR/image detection to validate interaction
     return True
+
+
+def interact_with_trainer(trainer_name: str) -> bool:
+    """Simulate interacting with a trainer NPC."""
+    print(f"[TRAINER] Talking to {trainer_name}")
+    return interact_with_npc(trainer_name)

--- a/utils/ocr_scanner.py
+++ b/utils/ocr_scanner.py
@@ -1,0 +1,17 @@
+"""Simple helpers to OCR the on-screen skills list."""
+
+from __future__ import annotations
+from typing import List
+
+from src.vision.ocr import screen_text
+
+
+def scan_skills_ui() -> List[str]:
+    """Return a list of skill names detected in the skills UI."""
+    text = screen_text()
+    skills: List[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            skills.append(line)
+    return skills


### PR DESCRIPTION
## Summary
- scan skills UI via new `ocr_scanner`
- configure skill requirements and trainer locations
- implement `ProfessionManager.train_missing_skills`
- provide helper for trainer interaction
- handle optional dependencies in importers
- include tests for profession manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e4f4745d08331bbc80c0fa09abe9e