### PR TITLE
Add trainer interaction skill arg

### DIFF
--- a/core/profession_manager.py
+++ b/core/profession_manager.py
@@ -29,5 +29,6 @@ class ProfessionManager:
             zone = trainer["planet"]
             coords = trainer["coords"]
             travel_to(zone, coords)
-            interact_with_trainer(trainer["name"])
+            for skill in missing:
+                interact_with_trainer(trainer["name"], skill)
 

--- a/tests/test_profession_manager.py
+++ b/tests/test_profession_manager.py
@@ -17,8 +17,8 @@ def test_train_missing_skills_travels(monkeypatch):
     def fake_travel(zone, coords):
         calls.setdefault("travel", []).append((zone, coords))
 
-    def fake_interact(name):
-        calls.setdefault("interact", []).append(name)
+    def fake_interact(name, skill):
+        calls.setdefault("interact", []).append((name, skill))
         return True
 
     monkeypatch.setattr("core.profession_manager.travel_to", fake_travel)
@@ -27,7 +27,7 @@ def test_train_missing_skills_travels(monkeypatch):
     pm.train_missing_skills()
 
     assert calls["travel"][0][0] == "tatooine"
-    assert calls["interact"][0] == "Artisan Trainer"
+    assert calls["interact"][0] == ("Artisan Trainer", "Novice Artisan")
 
 
 def test_train_missing_skills_no_action(monkeypatch):
@@ -44,7 +44,9 @@ def test_train_missing_skills_no_action(monkeypatch):
         called = True
 
     monkeypatch.setattr("core.profession_manager.travel_to", fake_travel)
-    monkeypatch.setattr("core.profession_manager.interact_with_trainer", lambda n: True)
+    monkeypatch.setattr(
+        "core.profession_manager.interact_with_trainer", lambda n, s: True
+    )
 
     pm.train_missing_skills()
 

--- a/utils/npc_handler.py
+++ b/utils/npc_handler.py
@@ -9,7 +9,9 @@ def interact_with_npc(npc_name: str) -> bool:
     return True
 
 
-def interact_with_trainer(trainer_name: str) -> bool:
-    """Simulate interacting with a trainer NPC."""
+def interact_with_trainer(trainer_name: str, skill: str) -> bool:
+    """Simulate training with a profession trainer."""
     print(f"[TRAINER] Talking to {trainer_name}")
-    return interact_with_npc(trainer_name)
+    interact_with_npc(trainer_name)
+    print(f"[TRAINER] {trainer_name} teaches you {skill}")
+    return True


### PR DESCRIPTION
## Summary
- extend `interact_with_trainer` with a skill argument
- train all missing skills in `ProfessionManager`
- update profession manager tests for new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e5346742483318cc683cc89e18c7f