### PR TITLE
Normalize trainer data format

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -5,7 +5,7 @@
 - **Mode runner**: `main.py` and `runner.py` provide CLI entry points to launch different automation modes.
 - **Quest database**: `src/db` holds SQLite schema, quest insertion helpers, and utilities for viewing quests.
 - **Training helpers**: `trainer_data_loader.py`, `trainer_visit.py`, and the `find_trainer.py` CLI locate NPC trainers and automate visits.
-- **Trainer navigator**: `scripts/logic/trainer_navigator.py` lists nearby trainers and records visits in `logs/training_log.txt`. It can also write JSON lines to `logs/training.json` using data from `data/trainers.yaml`.
+- **Trainer navigator**: `scripts/logic/trainer_navigator.py` lists nearby trainers and records visits in `logs/training_log.txt`. It can also write JSON lines to `logs/training.json` using data from `data/trainers.json`.
 
 ## Modules Needing Work
 - `quest_selector.py` – loads legacy quests and DB entries with filtering support; still needs scoring improvements.

--- a/README.md
+++ b/README.md
@@ -235,19 +235,18 @@ python scripts/cli/find_trainer.py artisan --planet tatooine --city mos_eisley
 
 The `profession` argument is required. `--planet` and `--city` default to
 `tatooine` and `mos_eisley`. When a matching entry is found in
-`data/trainers.yaml`, the trainer's name and coordinates are printed; otherwise
-a helpful message is shown.
-The lookup uses `utils.get_trainer_location.get_trainer_location()` to read
-locations from the YAML file. By default the file is loaded relative to the
+`data/trainers.json`, the trainer's name and coordinates are printed; otherwise
+the lookup uses `utils.get_trainer_location.get_trainer_location()` to read
+locations from the JSON file. By default the file is loaded relative to the
 project root, but you can override the location by setting the
 `TRAINER_FILE` environment variable or passing a custom path to
 `utils.load_trainers.load_trainers()`.
 Trainer coordinates are currently curated manually. A future script may
-automate populating `data/trainers.yaml` once reliable NPC extraction is
+automate populating `data/trainers.json` once reliable NPC extraction is
 available.
 
 Automating the visit is possible through `trainer_visit.visit_trainer()`. It
-loads coordinates from the same YAML file and directs an agent to travel to the
+loads coordinates from the same JSON file and directs an agent to travel to the
 trainer. Dialogue steps referencing "Trainer" trigger `train_with_npc()` to log
 the interaction.
 
@@ -263,16 +262,15 @@ script, defaulting to `tatooine` and `mos_eisley`.
 
 ## Trainer Navigator Script
 `scripts/logic/trainer_navigator.py` exposes helper functions for locating
-nearby trainers and logging training sessions. It expects a YAML file at
-`data/trainers.yaml` structured by profession, planet and city:
+nearby trainers and logging training sessions. Trainer locations are stored in
+`data/trainers.json` using a list of entries per profession:
 
-```yaml
-artisan:
-  tatooine:
-    mos_eisley:
-      name: "Artisan Trainer"
-      x: 3432
-      y: -4795
+```json
+{
+  "artisan": [
+    {"planet": "tatooine", "city": "mos_eisley", "name": "Artisan Trainer", "coords": [3432, -4795]}
+  ]
+}
 ```
 
 Use the module interactively to list trainers near a position and record the
@@ -301,7 +299,7 @@ python scripts/data/extract_trainers.py
 ```
 
 The script runs OCR on images under `docs/samples/` and writes structured
-results to `data/trainers.yaml`.
+results to `data/trainers.json`.
 
 ### Migration Note
 The JSON trainer data file has moved from `data/trainers/trainers.json` to

--- a/config/profession_config.py
+++ b/config/profession_config.py
@@ -5,17 +5,21 @@ REQUIRED_SKILLS = {
     "marksman": ["Novice Marksman"],
 }
 
+from utils.load_trainers import load_trainers
+
+
+def _primary(entries):
+    if not entries:
+        return {}
+    first = entries[0]
+    return {
+        "planet": first.get("planet"),
+        "city": first.get("city"),
+        "coords": first.get("coords"),
+        "name": first.get("name"),
+    }
+
+
 TRAINER_BY_PROFESSION = {
-    "artisan": {
-        "planet": "tatooine",
-        "city": "mos_eisley",
-        "coords": [3432, -4795],
-        "name": "Artisan Trainer",
-    },
-    "marksman": {
-        "planet": "corellia",
-        "city": "coronet",
-        "coords": [-150, 60],
-        "name": "Marksman Trainer",
-    },
+    prof: _primary(entries) for prof, entries in load_trainers().items()
 }

--- a/core/profession_manager.py
+++ b/core/profession_manager.py
@@ -6,14 +6,32 @@ from typing import List, Dict
 from utils.movement_manager import travel_to
 from utils.npc_handler import interact_with_trainer
 from utils.ocr_scanner import scan_skills_ui
-from config.profession_config import REQUIRED_SKILLS, TRAINER_BY_PROFESSION
+from config.profession_config import REQUIRED_SKILLS
+from utils.load_trainers import load_trainers
 
 
 class ProfessionManager:
     """Manage profession progression and training."""
 
     def __init__(self, trainer_map: Dict[str, Dict] | None = None) -> None:
-        self.trainer_map = trainer_map or TRAINER_BY_PROFESSION
+        self.trainer_map = trainer_map or self.load_trainer_map()
+
+    @staticmethod
+    def load_trainer_map(trainer_file: str | None = None) -> Dict[str, Dict]:
+        """Return primary trainer mapping from the canonical data."""
+        data = load_trainers(trainer_file)
+        mapping: Dict[str, Dict] = {}
+        for profession, entries in data.items():
+            if not entries:
+                continue
+            entry = entries[0]
+            mapping[profession] = {
+                "planet": entry.get("planet"),
+                "city": entry.get("city"),
+                "coords": entry.get("coords"),
+                "name": entry.get("name", f"{profession} trainer"),
+            }
+        return mapping
 
     # --------------------------------------------------
     def train_missing_skills(self) -> None:

--- a/data/trainers.json
+++ b/data/trainers.json
@@ -1,20 +1,12 @@
 {
-  "artisan": {
-    "corellia": {
-      "coronet": {"name": "Artisan Trainer", "x": -123, "y": 44}
-    },
-    "tatooine": {
-      "mos_eisley": {"name": "Artisan Trainer", "x": 3432, "y": -4795}
-    }
-  },
-  "marksman": {
-    "corellia": {
-      "coronet": {"name": "Marksman Trainer", "x": -150, "y": 60}
-    }
-  },
-  "Master Combat Medic": {
-    "planet": "Corellia",
-    "city": "Coronet",
-    "coordinates": [125, -3421]
-  }
+  "artisan": [
+    {"planet": "tatooine", "city": "mos_eisley", "coords": [3432, -4795], "name": "Artisan Trainer"},
+    {"planet": "corellia", "city": "coronet", "coords": [-123, 44], "name": "Artisan Trainer"}
+  ],
+  "marksman": [
+    {"planet": "corellia", "city": "coronet", "coords": [-150, 60], "name": "Marksman Trainer"}
+  ],
+  "Master Combat Medic": [
+    {"planet": "Corellia", "city": "Coronet", "coords": [125, -3421], "name": "Master Combat Medic"}
+  ]
 }

--- a/modules/travel/trainer_travel.py
+++ b/modules/travel/trainer_travel.py
@@ -35,11 +35,11 @@ def travel_to_trainer(profession: str, trainer_data: Dict[str, dict], agent=None
         print(f"[Travel] No trainer data for {profession}")
         return None
 
-    # Pick the first available planet/city entry
-    planet, cities = next(iter(prof_entry.items()))
-    city, entry = next(iter(cities.items()))
-    dest_x = entry.get("x", 0)
-    dest_y = entry.get("y", 0)
+    entry = prof_entry[0]
+    planet = entry.get("planet", DEFAULT_START_PLANET)
+    city = entry.get("city", DEFAULT_START_CITY)
+    coords = entry.get("coords") or [entry.get("x", 0), entry.get("y", 0)]
+    dest_x, dest_y = coords
 
     # Plan the shuttle route so we can log the chosen path
     route = shuttle.plan_route(

--- a/scripts/cli/find_trainer.py
+++ b/scripts/cli/find_trainer.py
@@ -21,7 +21,7 @@ def main(argv=None):
         print(
             f"No trainer found for {args.profession} in {args.city}, {args.planet}."
         )
-        print("Check trainers.yaml for available locations.")
+        print("Check trainers.json for available locations.")
         return None
 
 

--- a/tests/test_check_and_train_skills.py
+++ b/tests/test_check_and_train_skills.py
@@ -9,9 +9,11 @@ import src.main as main
 def test_check_and_train_triggers_travel(monkeypatch):
     calls = {}
 
-    monkeypatch.setattr(main, "load_trainers", lambda: {
-        "artisan": {"tatooine": {"mos_eisley": {"name": "Trainer", "x": 1, "y": 2}}}
-    })
+    monkeypatch.setattr(
+        main,
+        "load_trainers",
+        lambda: {"artisan": [{"planet": "tatooine", "city": "mos_eisley", "name": "Trainer", "coords": [1, 2]}]},
+    )
     monkeypatch.setattr(
         main, "get_trainable_skills", lambda skills, tree: [("artisan", 1)]
     )

--- a/tests/test_trainer_navigator.py
+++ b/tests/test_trainer_navigator.py
@@ -20,8 +20,12 @@ class DummyLoad:
 
 def test_find_nearby_trainers(monkeypatch):
     data = {
-        "artisan": {"tatooine": {"mos_eisley": {"name": "Art", "x": 0, "y": 0}}},
-        "marksman": {"tatooine": {"mos_eisley": {"name": "Mark", "x": 10, "y": 0}}},
+        "artisan": [
+            {"planet": "tatooine", "city": "mos_eisley", "name": "Art", "coords": [0, 0]}
+        ],
+        "marksman": [
+            {"planet": "tatooine", "city": "mos_eisley", "name": "Mark", "coords": [10, 0]}
+        ],
     }
     loader = DummyLoad(data)
     monkeypatch.setattr(tn, "load_trainers", loader)
@@ -36,7 +40,9 @@ def test_find_nearby_trainers(monkeypatch):
 
 def test_threshold(monkeypatch):
     data = {
-        "artisan": {"tatooine": {"mos_eisley": {"name": "Art", "x": 100, "y": 0}}}
+        "artisan": [
+            {"planet": "tatooine", "city": "mos_eisley", "name": "Art", "coords": [100, 0]}
+        ]
     }
     loader = DummyLoad(data)
     monkeypatch.setattr(tn, "load_trainers", loader)
@@ -70,9 +76,15 @@ def test_log_training_event_json(tmp_path):
 
 def test_find_nearby_trainers_sorted(monkeypatch):
     data = {
-        "artisan": {"tatooine": {"mos_eisley": {"name": "Art", "x": 1, "y": 0}}},
-        "brawler": {"tatooine": {"mos_eisley": {"name": "Brawl", "x": 3, "y": 0}}},
-        "marksman": {"tatooine": {"mos_eisley": {"name": "Mark", "x": 5, "y": 0}}},
+        "artisan": [
+            {"planet": "tatooine", "city": "mos_eisley", "name": "Art", "coords": [1, 0]}
+        ],
+        "brawler": [
+            {"planet": "tatooine", "city": "mos_eisley", "name": "Brawl", "coords": [3, 0]}
+        ],
+        "marksman": [
+            {"planet": "tatooine", "city": "mos_eisley", "name": "Mark", "coords": [5, 0]}
+        ],
     }
     loader = DummyLoad(data)
     monkeypatch.setattr(tn, "load_trainers", loader)

--- a/tests/test_travel_to_trainer.py
+++ b/tests/test_travel_to_trainer.py
@@ -22,7 +22,11 @@ def test_travel_to_trainer_invokes_navigation(monkeypatch):
     monkeypatch.setattr(trainer_travel, "walk_to_coords", fake_walk)
     monkeypatch.setattr(shuttle, "plan_route", lambda *a, **k: [{"city": "mos_eisley"}, {"city": "coronet"}])
 
-    data = {"artisan": {"tatooine": {"mos_eisley": {"name": "Trainer", "x": 1, "y": 2}}}}
+    data = {
+        "artisan": [
+            {"planet": "tatooine", "city": "mos_eisley", "name": "Trainer", "coords": [1, 2]}
+        ]
+    }
     result = trainer_travel.travel_to_trainer("artisan", data, agent="A")
 
     assert result == "NAV"
@@ -37,7 +41,11 @@ def test_travel_to_trainer_logs_route(monkeypatch, capsys):
     monkeypatch.setattr(trainer_travel, "walk_to_coords", lambda *a, **k: None)
     monkeypatch.setattr(shuttle, "plan_route", lambda *a, **k: [{"city": "mos_eisley"}, {"city": "anchorhead"}])
 
-    data = {"brawler": {"tatooine": {"anchorhead": {"name": "Brawl", "x": 5, "y": 6}}}}
+    data = {
+        "brawler": [
+            {"planet": "tatooine", "city": "anchorhead", "name": "Brawl", "coords": [5, 6]}
+        ]
+    }
     trainer_travel.travel_to_trainer("brawler", data, agent="A")
 
     out = capsys.readouterr().out

--- a/utils/get_trainer_location.py
+++ b/utils/get_trainer_location.py
@@ -9,11 +9,21 @@ from .load_trainers import load_trainers
 TrainerLocation = Tuple[str, int, int]
 
 
-def get_trainer_location(profession: str, planet: str, city: str) -> Optional[TrainerLocation]:
+def get_trainer_location(
+    profession: str, planet: str, city: str
+) -> Optional[TrainerLocation]:
     """Return the trainer's name and coordinates if available."""
     data = load_trainers()
-    try:
-        entry = data[profession][planet][city]
-        return (entry["name"], entry["x"], entry["y"])
-    except KeyError:
-        return None
+    entries = data.get(profession, [])
+    for entry in entries:
+        if (
+            entry.get("planet", "").lower() == planet.lower()
+            and entry.get("city", "").lower() == city.lower()
+        ):
+            coords = entry.get("coords") or [entry.get("x"), entry.get("y")]
+            return (
+                entry.get("name", f"{profession} trainer"),
+                coords[0],
+                coords[1],
+            )
+    return None


### PR DESCRIPTION
## Summary
- store trainer locations in JSON lists
- normalize trainer data when loading
- let ProfessionManager load trainers from file
- adjust movement helpers and lookups to new format
- update docs and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ec35074fc8331b6fce13dbef4bfd4