### PR TITLE
Add pygetwindow to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ opencv-python
 pyautogui
 Pillow
 numpy
+pygetwindow


### PR DESCRIPTION
## Summary
- include `pygetwindow` dependency

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_685ed0972f38833191919790965a6161