### PR TITLE
Fix profession data path resolution

### DIFF
--- a/modules/professions/progress_tracker.py
+++ b/modules/professions/progress_tracker.py
@@ -1,12 +1,12 @@
 import json
-import os
 import re
+from pathlib import Path
 from typing import List, Optional, Dict
 
 from profession_logic.modules import xp_estimator
 
 # Default location for profession metadata JSON files
-DATA_DIR = os.path.join("android_ms11", "data", "professions")
+DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "professions"
 
 
 def _skill_name(text: str) -> str:
@@ -16,7 +16,7 @@ def _skill_name(text: str) -> str:
 
 def load_profession(profession: str) -> Dict:
     """Load profession data from ``DATA_DIR``."""
-    path = os.path.join(DATA_DIR, f"{profession.lower()}.json")
+    path = DATA_DIR / f"{profession.lower()}.json"
     with open(path, "r", encoding="utf-8") as fh:
         return json.load(fh)
 

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -30,7 +30,7 @@ def setup_profession(tmp_path):
 
 def test_recommend_next_skill(monkeypatch, tmp_path):
     prof_dir = setup_profession(tmp_path)
-    monkeypatch.setattr(progress_tracker, "DATA_DIR", str(prof_dir))
+    monkeypatch.setattr(progress_tracker, "DATA_DIR", prof_dir)
 
     rec = progress_tracker.recommend_next_skill("medic", [])
     assert rec == {"skill": "Novice Artisan", "xp": 0}
@@ -62,7 +62,7 @@ def test_recommend_next_skill(monkeypatch, tmp_path):
 
 def test_estimate_hours_to_next_skill(monkeypatch, tmp_path):
     prof_dir = setup_profession(tmp_path)
-    monkeypatch.setattr(progress_tracker, "DATA_DIR", str(prof_dir))
+    monkeypatch.setattr(progress_tracker, "DATA_DIR", prof_dir)
     monkeypatch.setattr(progress_tracker.xp_estimator, "estimate_xp_per_hour", lambda p, a: 500)
 
     hours = progress_tracker.estimate_hours_to_next_skill(


### PR DESCRIPTION
## Summary
- locate profession data relative to progress_tracker.py
- adjust tests for Path-based DATA_DIR

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ee0c7a5dc8331ad67ccad4d0b9afa