### PR TITLE
Add timeout to requests.get calls

### DIFF
--- a/data/importers/professions_importer.py
+++ b/data/importers/professions_importer.py
@@ -11,7 +11,7 @@ OUTPUT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'pars
 def fetch_profession_html(profession: str) -> str:
     """Fetch the raw HTML for a profession page."""
     url = f"{BASE_URL}{profession}/"
-    resp = requests.get(url)
+    resp = requests.get(url, timeout=10)
     resp.raise_for_status()
     return resp.text
 

--- a/scripts/importers/profession_importer.py
+++ b/scripts/importers/profession_importer.py
@@ -18,7 +18,7 @@ OUTPUT_DIR = os.path.join("android_ms11", "data", "professions")
 
 def fetch_profession_html(name: str) -> str:
     url = f"{BASE_URL}{name}/"
-    resp = requests.get(url)
+    resp = requests.get(url, timeout=10)
     resp.raise_for_status()
     return resp.text
 

--- a/src/data/importers/quests_importer.py
+++ b/src/data/importers/quests_importer.py
@@ -10,7 +10,7 @@ class QuestsImporter(BaseWikiImporter):
 
     def fetch_data(self):
         url = "https://swgr.org/wiki/quests/"
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         response.raise_for_status()
         return response.text
 

--- a/tests/test_profession_importer.py
+++ b/tests/test_profession_importer.py
@@ -31,7 +31,7 @@ def test_fetch_and_save(monkeypatch, tmp_path):
         def raise_for_status(self):
             pass
 
-    def fake_get(url):
+    def fake_get(url, *args, **kwargs):
         assert url == profession_importer.BASE_URL + "Doctor/"
         return DummyResponse()
 

--- a/tests/test_wiki_scraper.py
+++ b/tests/test_wiki_scraper.py
@@ -23,7 +23,7 @@ from utils import wiki_scraper
 def test_fetch_page_success(monkeypatch):
     expected_html = "<html>OK</html>"
 
-    def fake_get(url):
+    def fake_get(url, *args, **kwargs):
         assert url == wiki_scraper.WikiScraper.BASE_URL + "page"
         return types.SimpleNamespace(status_code=200, text=expected_html)
 
@@ -34,7 +34,7 @@ def test_fetch_page_success(monkeypatch):
 
 
 def test_fetch_page_error(monkeypatch):
-    def fake_get(url):
+    def fake_get(url, *args, **kwargs):
         return types.SimpleNamespace(status_code=404, text="")
 
     monkeypatch.setattr(wiki_scraper.requests, "get", fake_get)

--- a/utils/wiki_scraper.py
+++ b/utils/wiki_scraper.py
@@ -19,7 +19,7 @@ class WikiScraper:
 
     def fetch_page(self, page_path):
         url = self.BASE_URL + page_path
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         if response.status_code != 200:
             raise Exception(f"Failed to fetch {url}")
         return response.text


### PR DESCRIPTION
## Summary
- avoid hanging web requests with timeout parameter
- update tests to accept the new argument

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ee36047ec83318324e9cca231d764