### PR TITLE
Replace TODO prints with stub logic

### DIFF
--- a/src/execution/core.py
+++ b/src/execution/core.py
@@ -17,4 +17,4 @@ def execute_step(step: dict) -> None:
         from .quest import execute_quest
         execute_quest(step)
     else:
-        print(f"[TODO] Unsupported step type: {step_type}")
+        print(f"[Unsupported] Step type '{step_type}' is not implemented.")

--- a/src/mode_afk_combat.py
+++ b/src/mode_afk_combat.py
@@ -1,12 +1,14 @@
 
 """AFK combat automation helpers.
 
-Planned features include loading a combat macro, monitoring for whispers,
-and rotating through targets while the player is away.
+The real AFK combat system is not implemented yet. This stub simply
+prints messages that mimic basic target rotation and whisper monitoring.
 """
 
-def start_afk_combat(character_name: str):
+def start_afk_combat(character_name: str) -> None:
+    """Simulate passive combat actions for a character."""
+
     print(f"🛡️ AFK Combat Mode Activated for {character_name}...")
-    print("⚔️ [TODO] Load afk-combat macro, monitor for whispers, and trigger target rotation.")
+    print("⚔️ Rotating through targets and listening for whispers...")
     # Simulate test output
     print("⚔️ Simulation: Defeated 5 mobs at waypoint.")

--- a/src/mode_buff_by_tell.py
+++ b/src/mode_buff_by_tell.py
@@ -1,12 +1,14 @@
 
 """Utilities for buff-by-tell mode.
 
-This mode will monitor private tells and respond with queued buff macros
-when a request is detected.
+The full buff-by-tell system is still under construction. This stub
+demonstrates the expected console output when a request is handled.
 """
 
-def start_buff_by_tell(character_name: str):
+def start_buff_by_tell(character_name: str) -> None:
+    """Simulate responding to buff requests sent via tell."""
+
     print(f"📨 Buff-by-Tell Mode Activated for {character_name}...")
-    print("🧙 [TODO] Monitor tells for buff requests and respond with queued macros.")
+    print("🧙 Listening for buff requests and queueing macros...")
     # Simulate test output
     print("📨 Simulation: Responded to 2 buff requests.")

--- a/src/mode_crafting.py
+++ b/src/mode_crafting.py
@@ -1,12 +1,14 @@
 
 """Automation routines for crafting mode.
 
-This module will eventually load crafting macros, survey resources,
-and execute the steps required to craft a target item.
+The crafting system is largely unimplemented. For now the helper simply
+prints messages describing the high level actions that would occur.
 """
 
-def start_crafting(character_name: str):
+def start_crafting(character_name: str) -> None:
+    """Simulate a short crafting session for the given character."""
+
     print(f"🛠️ Crafting Mode Activated for {character_name}...")
-    print("🔧 [TODO] Load crafting macros, survey for resources, and craft target item.")
+    print("🔧 Surveying resources and executing crafting macros...")
     # Simulate test output
     print("🔧 Simulation: Crafted 2 Mineral Survey Devices.")

--- a/src/mode_medic.py
+++ b/src/mode_medic.py
@@ -1,12 +1,15 @@
 
 """Medic mode automation helpers.
 
-Future tasks involve loading healing macros, checking group status, and
-applying buffs as needed.
+This module currently provides a very small stub that simulates basic
+healing behaviour. The real automation logic for loading macros and
+monitoring group status has not been implemented yet.
 """
 
-def start_medic(character_name: str):
+def start_medic(character_name: str) -> None:
+    """Simulate healing and buffing nearby allies."""
+
     print(f"🩺 Medic Mode Activated for {character_name}...")
-    print("🧪 [TODO] Load healing macros, monitor group status, and apply buffs.")
+    print("🧪 Monitoring group status and applying basic heals...")
     # Simulate test output
     print("🧪 Simulation: Buffed 3 nearby players.")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,4 +17,4 @@ def test_execute_step_unknown(capsys):
     step = {"type": "dance"}
     execute_step(step)
     captured = capsys.readouterr()
-    assert "[TODO] Unsupported step type: dance" in captured.out
+    assert "[Unsupported] Step type 'dance' is not implemented." in captured.out

--- a/tests/test_mode_stubs.py
+++ b/tests/test_mode_stubs.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.mode_medic import start_medic
+from src.mode_afk_combat import start_afk_combat
+from src.mode_crafting import start_crafting
+from src.mode_buff_by_tell import start_buff_by_tell
+
+
+def test_start_medic_outputs_stub(capsys):
+    start_medic("Ezra")
+    captured = capsys.readouterr()
+    assert "Monitoring group status" in captured.out
+
+
+def test_start_afk_combat_outputs_stub(capsys):
+    start_afk_combat("Ezra")
+    captured = capsys.readouterr()
+    assert "Rotating through targets" in captured.out
+
+
+def test_start_crafting_outputs_stub(capsys):
+    start_crafting("Ezra")
+    captured = capsys.readouterr()
+    assert "Surveying resources" in captured.out
+
+
+def test_start_buff_by_tell_outputs_stub(capsys):
+    start_buff_by_tell("Ezra")
+    captured = capsys.readouterr()
+    assert "Listening for buff requests" in captured.out


### PR DESCRIPTION
## Summary
- clean up TODO prints in execution and mode helpers
- document stub status for automation modules
- update tests for new messages and add stub tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ee51c6b38833194c78baba93ef312