### PR TITLE
Stub OpenCV constants for TrainerScanner tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,16 @@ if 'PIL' not in sys.modules:
     sys.modules['PIL'] = pil_module
     sys.modules['PIL.Image'] = pil_image
 
-sys.modules.setdefault('cv2', types.SimpleNamespace(COLOR_RGB2BGR=None, cvtColor=lambda img, flag: img))
+sys.modules.setdefault(
+    'cv2',
+    types.SimpleNamespace(
+        COLOR_RGB2BGR=None,
+        COLOR_BGR2GRAY=None,
+        THRESH_BINARY=None,
+        cvtColor=lambda img, flag: img,
+        threshold=lambda img, *a, **k: (None, img),
+    ),
+)
 
 if 'numpy' not in sys.modules:
     np_module = types.ModuleType('numpy')


### PR DESCRIPTION
## Summary
- extend the `cv2` stub in tests to include `COLOR_BGR2GRAY`, `THRESH_BINARY`, and a dummy `threshold` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685eed5b76b48331a3570ae8703f896f