### PR TITLE
Add trainer skill scanning utility

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -6,10 +6,12 @@ from .trainer_ocr import (
     get_untrained_skills_from_text,
     scan_and_detect_untrained_skills,
 )
+from .trainer_scanner import scan_trainer_skills
 
 __all__ = [
     "preprocess_image",
     "extract_text_from_trainer_region",
     "get_untrained_skills_from_text",
     "scan_and_detect_untrained_skills",
+    "scan_trainer_skills",
 ]

--- a/core/trainer_scanner.py
+++ b/core/trainer_scanner.py
@@ -1,0 +1,28 @@
+"""OCR utilities for scanning trainer skill lists."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+import pyautogui
+import pytesseract
+
+
+# Default screen region for trainer skills (left, top, width, height)
+DEFAULT_REGION: Tuple[int, int, int, int] | None = None
+
+
+def scan_trainer_skills(region: Tuple[int, int, int, int] | None = DEFAULT_REGION) -> List[str]:
+    """Capture ``region`` of the screen and return detected skill names."""
+    screenshot = pyautogui.screenshot(region=region)
+    img = cv2.cvtColor(np.array(screenshot), cv2.COLOR_BGR2GRAY)
+    _ignored, thresh = cv2.threshold(img, 127, 255, cv2.THRESH_BINARY)
+    text = pytesseract.image_to_string(thresh)
+    skills: List[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            skills.append(line)
+    return skills

--- a/tests/test_trainer_scanner.py
+++ b/tests/test_trainer_scanner.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.trainer_scanner import scan_trainer_skills
+import pyautogui
+import cv2
+import pytesseract
+
+
+def test_scan_trainer_skills(monkeypatch):
+    test_img = Image.new("RGB", (10, 10), color="white")
+
+    monkeypatch.setattr(pyautogui, "screenshot", lambda region=None: test_img)
+    monkeypatch.setattr(cv2, "cvtColor", lambda img, flag: img)
+    monkeypatch.setattr(cv2, "threshold", lambda img, *a, **k: (None, img), raising=False)
+    monkeypatch.setattr(pytesseract, "image_to_string", lambda img: "Skill A\nSkill B")
+
+    skills = scan_trainer_skills()
+    assert skills == ["Skill A", "Skill B"]


### PR DESCRIPTION
## Summary
- implement `scan_trainer_skills` to OCR trainer skill lists
- expose new helper from `core`
- add regression test using monkeypatch for screenshot/OCR stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685eee3397ac8331a8ab35c76f8458cd