### PR TITLE
Improve trainer scanner docs and add screen tools

### DIFF
--- a/core/trainer_scanner.py
+++ b/core/trainer_scanner.py
@@ -1,8 +1,14 @@
-"""OCR utilities for scanning trainer skill lists."""
+"""Utilities for OCR'ing skill lists from a trainer window.
+
+This module exposes :func:`scan_trainer_skills` and a small :class:`TrainerScanner`
+wrapper.  Both capture a region of the screen, apply simple thresholding and
+pass the result through ``pytesseract`` to extract the names of skills the
+trainer offers.
+"""
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Tuple
 
 import cv2
 import numpy as np
@@ -14,13 +20,25 @@ import pytesseract
 DEFAULT_REGION: Tuple[int, int, int, int] | None = None
 
 
-def scan_trainer_skills(region: Tuple[int, int, int, int] | None = DEFAULT_REGION) -> List[str]:
-    """Capture ``region`` of the screen and return detected skill names."""
+def scan_trainer_skills(region: Tuple[int, int, int, int] | None = DEFAULT_REGION) -> list[str]:
+    """Capture ``region`` of the screen and return detected skill names.
+
+    Parameters
+    ----------
+    region:
+        Screen coordinates as ``(left, top, width, height)`` of the area to
+        capture.  When ``None`` the entire screen is scanned.
+
+    Returns
+    -------
+    list[str]
+        Detected skill names in top-to-bottom order.
+    """
     screenshot = pyautogui.screenshot(region=region)
     img = cv2.cvtColor(np.array(screenshot), cv2.COLOR_BGR2GRAY)
     _ignored, thresh = cv2.threshold(img, 127, 255, cv2.THRESH_BINARY)
     text = pytesseract.image_to_string(thresh)
-    skills: List[str] = []
+    skills: list[str] = []
     for line in text.splitlines():
         line = line.strip()
         if line:
@@ -34,6 +52,6 @@ class TrainerScanner:
     def __init__(self, region: Tuple[int, int, int, int] | None = DEFAULT_REGION) -> None:
         self.region = region
 
-    def scan(self) -> List[str]:
+    def scan(self) -> list[str]:
         """Return detected trainer skills from :attr:`region`."""
         return scan_trainer_skills(self.region)

--- a/utils/screen_tools.py
+++ b/utils/screen_tools.py
@@ -1,0 +1,62 @@
+"""Tools for capturing and analyzing the in-game trainer window."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cv2
+import numpy as np
+import pyautogui
+from PIL import Image
+
+
+def capture_trainer_window(
+    region: Tuple[int, int, int, int] | None = None,
+) -> Image.Image:
+    """Return a screenshot of the trainer window or ``region``.
+
+    Parameters
+    ----------
+    region:
+        Optional ``(left, top, width, height)`` tuple indicating the portion of
+        the screen to capture.  When ``None`` the entire screen is captured.
+
+    Returns
+    -------
+    PIL.Image.Image
+        Screenshot image captured via ``pyautogui``.
+    """
+    return pyautogui.screenshot(region=region)
+
+
+def locate_skill_boxes(image: Image.Image | np.ndarray) -> list[Tuple[int, int, int, int]]:
+    """Locate skill box regions in ``image``.
+
+    Parameters
+    ----------
+    image:
+        Image of the trainer window. ``PIL`` images are converted to ``numpy``
+        arrays automatically.
+
+    Returns
+    -------
+    list[tuple[int, int, int, int]]
+        Bounding boxes for detected skill boxes as ``(x, y, w, h)`` tuples.
+    """
+    if isinstance(image, Image.Image):
+        arr = np.array(image)
+    else:
+        arr = image
+
+    gray = cv2.cvtColor(arr, cv2.COLOR_BGR2GRAY)
+    _ignored, thresh = cv2.threshold(gray, 127, 255, cv2.THRESH_BINARY)
+    contours, _ignored2 = cv2.findContours(
+        thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+    )
+    boxes: list[Tuple[int, int, int, int]] = []
+    for cnt in contours:
+        x, y, w, h = cv2.boundingRect(cnt)
+        if w > 10 and h > 10:
+            boxes.append((x, y, w, h))
+    return boxes
+


### PR DESCRIPTION
## Summary
- expand `core.trainer_scanner` docs and typing
- add a new `utils.screen_tools` helper module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685efb7a2f14833196a6d1ae426136f2