### PR TITLE
Update profession metadata path

### DIFF
--- a/android_ms11/data/professions/README.md
+++ b/android_ms11/data/professions/README.md
@@ -1,2 +1,3 @@
 Profession metadata lives here. JSON files are named after the profession,
-e.g. ``medic.json``. These are consumed by the ``progress_tracker`` module.
+e.g. ``medic.json``. These are consumed by the ``progress_tracker`` module,
+which reads from this directory by default.

--- a/modules/professions/progress_tracker.py
+++ b/modules/professions/progress_tracker.py
@@ -6,7 +6,11 @@ from typing import List, Optional, Dict
 from profession_logic.modules import xp_estimator
 
 # Default location for profession metadata JSON files
-DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "professions"
+#
+# Profession JSON files are stored under ``android_ms11/data/professions``.
+# ``DATA_DIR`` points to that location by default so the tracker can load
+# profession info without additional configuration.
+DATA_DIR = Path(__file__).resolve().parents[2] / "android_ms11" / "data" / "professions"
 
 
 def _skill_name(text: str) -> str:


### PR DESCRIPTION
## Summary
- reference `android_ms11/data/professions` in `progress_tracker`
- clarify README location of profession metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f3eefd3208331a771a2a11adb70e2