### PR TITLE
Update docs for phases and modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ settings together. Use the ``--profile`` option to load one:
 python src/main.py --profile questing
 ```
 
+The ``--mode`` flag overrides the ``default_mode`` defined in `config/config.json`.
+Each runtime profile is a small JSON file describing the starting location,
+objectives, and priority for a task. See below for an example profile.
+
+An example runtime profile looks like this:
+
+```json
+{
+  "mode": "medic",
+  "location": "Naboo",
+  "objectives": [
+    "Heal players in Theed",
+    "Restock medical supplies"
+  ],
+  "priority": 1
+}
+```
+
 ## Discord Relay Bot
 The relay bot depends on the `discord.py` package. Enable it by editing
 `config/config.json` (set `enable_discord_relay`) and
@@ -205,6 +223,26 @@ Or start the demo with relay enabled:
 ```bash
 python src/main.py --mode medic
 ```
+
+## Credit and XP Tracking
+Session logs are managed by `core.session_manager.SessionManager`. When a session starts, it records the starting credit balance and XP value. Calling `end_session()` writes a JSON report under `logs/` showing credits earned and XP gained.
+
+You can track smaller actions with `XPManager`:
+
+```python
+from src.xp_manager import XPManager
+
+xp = XPManager("Ezra")
+xp.record_action("quest_complete")
+xp.end_session()
+```
+
+Each action adds an entry to `logs/xp_tracking/` so you can review progress later.
+
+## Whisper Relay Setup
+The optional Discord relay forwards in-game whispers to a Discord DM. Enable it in `config/config.json` and configure credentials in `config/discord_config.json`.
+
+When `relay_mode` is set to `auto` or `manual`, replies are sent back to the game via `game_bridge.GameBridge`. The helper `whisper_monitor.py` watches the screen and queues new whispers for dispatch.
 
 ## Legacy Quest Manager CLI
 Use the legacy quest tool to explore old mission data.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,20 +2,33 @@
 
 Android MS11 aims to be an advanced interface assistant for long-session open-world automation. The project is maintained by **Project Galactic Beholder** and builds on the archived MS11-Core code.
 
-## Phases
 
-### Questing 🚧
-Modules focus on selecting and running quests. Key pieces include:
-- `quest_selector.py` and `quest_executor.py` for quest flow
-- `quest_engine.py` plus movement helpers
+## Phase 1 Features
 
-Todo work recorded in `NOTES.md` includes scoring improvements and fleshing out step execution. Individual files also contain placeholders, such as the UI hook in `src/execution/dialogue.py` and the walking logic in `src/movement/movement_profiles.py`.
+The initial release focuses on reliable quest execution and basic session tracking.
 
-### Support 🚧
-Support scripts provide in-game assistance such as healing or training runs. Examples are `mode_medic.py`, `mode_buff_by_tell.py`, `trainer_seeker.py`, and travel helpers under `modules/travel`. XP tracking via `xp_manager.py`, `xp_session.py`, and `xp_tracker.py` is considered stable.
+- `quest_selector.py` and `quest_executor.py` provide the quest flow logic.
+- `quest_engine.py` plus movement helpers automate travel between objectives.
+- `xp_manager.py`, `xp_session.py`, and `xp_tracker.py` record XP and credit gains.
 
-### AI Interaction 🔮
-Early AI features integrate with Discord and text generation. `discord_relay.py` supplies placeholder AI replies while `story_generator.py` uses LangChain to generate short stories. More complete conversational loops are planned.
+Todo work recorded in `NOTES.md` includes improving scoring and fleshing out step execution. Some modules still contain placeholders &ndash; for example the UI hook in `src/execution/dialogue.py` and walking logic in `src/movement/movement_profiles.py`.
+
+## Phase 2 Plans
+
+The next phase expands support functionality. Planned work includes:
+
+- Finishing healer and buff modes such as `mode_medic.py` and `mode_buff_by_tell.py`.
+- Adding trainer automation via `trainer_seeker.py` and the travel helpers under `modules/travel`.
+- Integrating profession leveling data from `profession_logic` modules.
+
+## Phase 3 Vision
+
+Longer term development aims to incorporate AI-driven interaction. Early pieces already exist:
+
+- `discord_relay.py` can forward whispers to Discord with optional AI replies.
+- `story_generator.py` uses LangChain to produce short stories.
+
+Future work will expand conversational loops and add smarter behavior modules.
 
 Status markers used above:
 - ✅ stable


### PR DESCRIPTION
## Summary
- outline phase features and plans in `docs/roadmap.md`
- add runtime profile example and explain `--mode` flag in README
- describe credit/XP tracking and whisper relay usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f4b7620c08331be1fabb21d3ca3c1