### PR TITLE
Remove unused imports flagged by lint

### DIFF
--- a/archive/ms11-core/xp_tracker.py
+++ b/archive/ms11-core/xp_tracker.py
@@ -3,7 +3,6 @@ XP Tracker module for Android MS11.
 Combines OCR and heuristic estimation to track character progression.
 """
 
-import time
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 

--- a/core/profession_manager.py
+++ b/core/profession_manager.py
@@ -1,7 +1,7 @@
 """Utilities for managing profession skill training."""
 
 from __future__ import annotations
-from typing import List, Dict
+from typing import Dict
 
 from utils.movement_manager import travel_to
 from utils.npc_handler import interact_with_trainer

--- a/core/trainer_ocr.py
+++ b/core/trainer_ocr.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 from PIL import Image

--- a/discord_relay.py
+++ b/discord_relay.py
@@ -1,4 +1,3 @@
-import asyncio
 import discord
 from discord.ext import commands
 
@@ -35,7 +34,7 @@ class DiscordRelay(commands.Cog):
     async def relay_to_discord(self, sender: str, message: str) -> str | None:
         """Send a whisper to Discord based on the active mode."""
         try:
-            user = await self.bot.fetch_user(self.target_user_id)
+            await self.bot.fetch_user(self.target_user_id)
         except Exception as e:
             print(f"[Error] Could not fetch user: {e}")
             return None

--- a/modules/training/trainer_seeker.py
+++ b/modules/training/trainer_seeker.py
@@ -7,7 +7,7 @@ run a training macro.
 
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 from modules.professions import progress_tracker
 from scripts.logic import trainer_navigator

--- a/modules/travel/trainer_travel.py
+++ b/modules/travel/trainer_travel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict
 
 from scripts.travel import shuttle
 from src.movement.movement_profiles import walk_to_coords

--- a/scripts/logic/trainer_navigator.py
+++ b/scripts/logic/trainer_navigator.py
@@ -13,7 +13,7 @@ import math
 import os
 import json
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from utils.load_trainers import load_trainers
 from utils.get_trainer_location import get_trainer_location

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,7 +1,2 @@
 """Test environment initialization importing optional dependencies."""
 
-# Ensure BeautifulSoup is available for tests that rely on it.
-try:
-    import bs4  # noqa: F401
-except Exception:
-    pass

--- a/src/main.py
+++ b/src/main.py
@@ -17,9 +17,6 @@ from core.session_manager import SessionManager
 from utils.load_trainers import load_trainers
 from modules.skills.training_check import get_trainable_skills
 from modules.travel.trainer_travel import travel_to_trainer
-from src.movement.agent_mover import MovementAgent
-from src.movement.movement_profiles import patrol_route
-from src.training.trainer_visit import visit_trainer
 
 from android_ms11.modes import (
     quest_mode,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,6 @@ if 'yaml' not in sys.modules:
     yaml_module.safe_load = safe_load
     sys.modules['yaml'] = yaml_module
 
-import os
 from pathlib import Path
 import pytest
 

--- a/tests/test_discord_relay.py
+++ b/tests/test_discord_relay.py
@@ -1,7 +1,5 @@
 import os
 import sys
-import os
-import sys
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 import types

--- a/tests/test_feedback_step_executor.py
+++ b/tests/test_feedback_step_executor.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from types import SimpleNamespace, ModuleType
+from types import ModuleType
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_profession_manager.py
+++ b/tests/test_profession_manager.py
@@ -1,11 +1,9 @@
 import os
 import sys
-import bs4
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.profession_manager import ProfessionManager
-import utils.ocr_scanner as ocr_scanner
 
 
 def test_train_missing_skills_travels(monkeypatch):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from unittest.mock import MagicMock
-import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_quest_selector.py
+++ b/tests/test_quest_selector.py
@@ -7,7 +7,6 @@ import random
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src import quest_selector
-from src.db import database
 
 
 def make_db():

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,7 +1,6 @@
 import os
 import json
 import sys
-from datetime import datetime, timedelta
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_story_generator.py
+++ b/tests/test_story_generator.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import pytest
 from unittest.mock import MagicMock, patch, ANY
 import types
 

--- a/tests/test_trainer_navigator.py
+++ b/tests/test_trainer_navigator.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import json
-from importlib import reload
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_trainer_ocr.py
+++ b/tests/test_trainer_ocr.py
@@ -4,7 +4,6 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core import trainer_ocr
-import pytesseract
 
 
 def test_get_untrained_skills_from_text():

--- a/tests/test_travel_to_trainer.py
+++ b/tests/test_travel_to_trainer.py
@@ -5,7 +5,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from modules.travel import trainer_travel
 from scripts.travel import shuttle
-from src.movement import movement_profiles
 
 
 def test_travel_to_trainer_invokes_navigation(monkeypatch):

--- a/tests/test_xp_manager.py
+++ b/tests/test_xp_manager.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from unittest.mock import MagicMock
-import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/utils/fetch_legacy_html.py
+++ b/utils/fetch_legacy_html.py
@@ -1,6 +1,5 @@
 # src/utils/fetch_legacy_html.py
 
-import os
 from pathlib import Path
 from playwright.sync_api import sync_playwright
 

--- a/utils/screen_capture.py
+++ b/utils/screen_capture.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Tuple, Optional
+from typing import Tuple
 
 import pyautogui
 

--- a/utils/window_finder.py
+++ b/utils/window_finder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import Iterable
 
 import pygetwindow
 


### PR DESCRIPTION
## Summary
- clean up unused imports in various modules
- adjust `discord_relay.safe_send_user` logic
- drop redundant `asyncio` import

## Testing
- `pyflakes .`
- `pytest -q` *(fails: tests/test_main_config.py::test_main_uses_default_mode)*

------
https://chatgpt.com/codex/tasks/task_b_685f4cdaf79c8331a953662581218d45