### PR TITLE
Restore imports for tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -17,9 +17,13 @@ from core.session_manager import SessionManager
 from utils.load_trainers import load_trainers
 from modules.skills.training_check import get_trainable_skills
 from modules.travel.trainer_travel import travel_to_trainer
-from src.movement.agent_mover import MovementAgent
-from src.movement.movement_profiles import patrol_route
-from src.training.trainer_visit import visit_trainer
+from src.movement.agent_mover import MovementAgent  # noqa: F401
+from src.movement.movement_profiles import patrol_route  # noqa: F401
+from src.training.trainer_visit import visit_trainer  # noqa: F401
+
+MovementAgent
+patrol_route
+visit_trainer
 
 from android_ms11.modes import (
     quest_mode,


### PR DESCRIPTION
## Summary
- keep MovementAgent, patrol_route, and visit_trainer imports in `src/main.py`
- reference these imports so pyflakes passes

## Testing
- `pyflakes src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f5012187883319c5154632b176447