### PR TITLE
Add quest/combat mode implementations

### DIFF
--- a/android_ms11/modes/combat_assist_mode.py
+++ b/android_ms11/modes/combat_assist_mode.py
@@ -1,3 +1,15 @@
-def run(config):
-    """Main entry point for this mode."""
-    pass
+"""Combat assist mode implementation."""
+
+from core.session_manager import SessionManager
+from src.mode_afk_combat import start_afk_combat
+
+
+def run(config: dict, session: SessionManager) -> None:
+    """Run combat assist loop using ``session`` for tracking."""
+
+    character = config.get("character_name", "Unknown")
+    print(f"[COMBAT] Starting combat assist for {character}")
+    session.add_action("combat_assist_start")
+    start_afk_combat(character)
+    session.add_action("combat_assist_end")
+

--- a/android_ms11/modes/quest_mode.py
+++ b/android_ms11/modes/quest_mode.py
@@ -1,3 +1,24 @@
-def run(config):
-    """Main entry point for this mode."""
-    pass
+"""Quest mode implementation."""
+
+from core.session_manager import SessionManager
+from src.quest_selector import select_quest
+from src.quest_executor import execute_quest
+
+
+def run(config: dict, session: SessionManager) -> None:
+    """Run quest mode using ``session`` to track actions."""
+
+    character = config.get("character_name", "Unknown")
+    print(f"[QUEST] Starting quest mode for {character}")
+    session.add_action("quest_mode_start")
+
+    quest = select_quest(character)
+    if quest is None:
+        print("\u26A0\ufe0f No available quest.")
+        session.add_action("quest_mode_end")
+        return
+
+    execute_quest(quest, dry_run=True)
+    session.add_action("quest_complete")
+    session.add_action("quest_mode_end")
+

--- a/android_ms11/tests/test_mode_runs.py
+++ b/android_ms11/tests/test_mode_runs.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from android_ms11.modes import quest_mode, combat_assist_mode
+
+
+class DummySession:
+    def __init__(self):
+        self.actions = []
+
+    def add_action(self, action: str):
+        self.actions.append(action)
+
+    def set_start_credits(self, *a, **k):
+        pass
+
+    def set_end_credits(self, *a, **k):
+        pass
+
+    def end_session(self):
+        pass
+
+
+def test_quest_mode_run_invokes_utils(monkeypatch):
+    called = {}
+    monkeypatch.setattr(quest_mode, "select_quest", lambda name: {"title": "Demo", "steps": []})
+
+    def fake_exec(q, dry_run=True):
+        called["quest"] = q
+    monkeypatch.setattr(quest_mode, "execute_quest", fake_exec)
+
+    session = DummySession()
+    quest_mode.run({"character_name": "Ezra"}, session)
+
+    assert called["quest"]["title"] == "Demo"
+    assert session.actions[0] == "quest_mode_start"
+    assert session.actions[-1] == "quest_mode_end"
+
+
+def test_combat_assist_mode_run_invokes_loop(monkeypatch):
+    captured = {}
+
+    def fake_start(name):
+        captured["name"] = name
+    monkeypatch.setattr(combat_assist_mode, "start_afk_combat", fake_start)
+
+    session = DummySession()
+    combat_assist_mode.run({"character_name": "Ezra"}, session)
+
+    assert captured["name"] == "Ezra"
+    assert "combat_assist_start" in session.actions
+    assert session.actions[-1] == "combat_assist_end"

--- a/src/main.py
+++ b/src/main.py
@@ -121,11 +121,16 @@ def main(argv: list[str] | None = None) -> None:
         print("[DISCORD] discord.py not available; relay disabled")
 
     # Initialize new session using the mode from CLI or profile
-    SessionManager(mode=mode)
+    session = SessionManager(mode=mode)
 
     handler = MODE_HANDLERS.get(mode)
     if handler:
-        handler(config)
+        import inspect
+
+        if len(inspect.signature(handler).parameters) == 2:
+            handler(config, session)
+        else:
+            handler(config)
     else:
         print(f"[MODE] Unknown mode '{mode}'")
 


### PR DESCRIPTION
## Summary
- implement quest and combat assist mode runners
- pass SessionManager to mode handlers when supported
- update unit tests for new signatures
- test quest/combat mode stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f56c841b08331baab59155b2a8349