### PR TITLE
Pass session to mode handlers

### DIFF
--- a/android_ms11/modes/crafting_mode.py
+++ b/android_ms11/modes/crafting_mode.py
@@ -1,3 +1,3 @@
-def run(config):
+def run(config, session=None):
     """Main entry point for this mode."""
     pass

--- a/android_ms11/modes/dancer_mode.py
+++ b/android_ms11/modes/dancer_mode.py
@@ -1,3 +1,3 @@
-def run(config):
+def run(config, session=None):
     """Main entry point for this mode."""
     pass

--- a/android_ms11/modes/medic_mode.py
+++ b/android_ms11/modes/medic_mode.py
@@ -1,3 +1,3 @@
-def run(config):
+def run(config, session=None):
     """Main entry point for this mode."""
     pass

--- a/android_ms11/modes/profession_mode.py
+++ b/android_ms11/modes/profession_mode.py
@@ -1,3 +1,3 @@
-def run(config):
+def run(config, session=None):
     """Main entry point for this mode."""
     pass

--- a/android_ms11/modes/whisper_mode.py
+++ b/android_ms11/modes/whisper_mode.py
@@ -1,3 +1,3 @@
-def run(config):
+def run(config, session=None):
     """Main entry point for this mode."""
     pass

--- a/src/main.py
+++ b/src/main.py
@@ -125,12 +125,7 @@ def main(argv: list[str] | None = None) -> None:
 
     handler = MODE_HANDLERS.get(mode)
     if handler:
-        import inspect
-
-        if len(inspect.signature(handler).parameters) == 2:
-            handler(config, session)
-        else:
-            handler(config)
+        handler(config, session)
     else:
         print(f"[MODE] Unknown mode '{mode}'")
 

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import importlib
-import inspect
 import pytest
 
 # Allow imports from project root
@@ -27,15 +26,11 @@ def test_mode_stubs_run(module_name, monkeypatch):
     if module_name == "combat_assist_mode":
         monkeypatch.setattr(mod, "start_afk_combat", lambda *a, **k: None)
 
-    params = inspect.signature(mod.run).parameters
-    if len(params) == 2:
-        class DummySession:
-            def add_action(self, *a, **k):
-                pass
+    class DummySession:
+        def add_action(self, *a, **k):
+            pass
 
-        mod.run({}, DummySession())
-    else:
-        mod.run({})
+    mod.run({}, DummySession())
 
 @pytest.mark.parametrize("mode", list(STUB_MAP.keys()))
 def test_main_selector_invokes_stub(monkeypatch, mode):


### PR DESCRIPTION
## Summary
- always pass the session manager object to each handler in `main`
- allow stub mode `run` functions to accept a session parameter
- update tests for new handler interface

## Testing
- `pytest tests/test_modes.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f5879ab4c8331915a194a674b0573