### PR TITLE
Add new mode stubs and support utilities

### DIFF
--- a/android_ms11/README.md
+++ b/android_ms11/README.md
@@ -13,6 +13,9 @@ function which is selected by `src.main` based on the chosen mode.
 - `profession_mode` – handles profession training tasks.
 - `quest_mode` – runs quest step sequences.
 - `whisper_mode` – monitors and relays whispers.
+- `support_mode` – coordinates following, supporting, and party joining.
+- `bounty_farming_mode` – stub for hunting bounties.
+- `entertainer_mode` – performs entertainer activities.
 
 ## Running a mode
 

--- a/android_ms11/core/follow_manager.py
+++ b/android_ms11/core/follow_manager.py
@@ -1,0 +1,6 @@
+"""Stub follow manager."""
+
+
+def follow_target_loop():
+    """Simulate following a target."""
+    print("📡 Following target...")

--- a/android_ms11/core/party_monitor.py
+++ b/android_ms11/core/party_monitor.py
@@ -1,0 +1,6 @@
+"""Stub party monitor."""
+
+
+def auto_join_party():
+    """Simulate waiting for party invite."""
+    print("🎉 Waiting for party invite...")

--- a/android_ms11/core/support_ai.py
+++ b/android_ms11/core/support_ai.py
@@ -1,0 +1,6 @@
+"""Stub support AI routines."""
+
+
+def assist_party():
+    """Simulate assisting party members."""
+    print("🤖 Assisting party with buffs and heals...")

--- a/android_ms11/modes/bounty_farming_mode.py
+++ b/android_ms11/modes/bounty_farming_mode.py
@@ -1,0 +1,6 @@
+"""Bounty farming mode stub."""
+
+
+def run(session=None):
+    """Placeholder for bounty farming behavior."""
+    print("💰 Bounty farming...")

--- a/android_ms11/modes/entertainer_mode.py
+++ b/android_ms11/modes/entertainer_mode.py
@@ -1,0 +1,6 @@
+"""Entertainer mode stub."""
+
+
+def run(session=None):
+    """Placeholder for entertainer behavior."""
+    print("🎭 Performing entertainment routines...")

--- a/android_ms11/modes/support_mode.py
+++ b/android_ms11/modes/support_mode.py
@@ -1,0 +1,10 @@
+"""Support mode implementation using core helpers."""
+
+from android_ms11.core import follow_manager, support_ai, party_monitor
+
+
+def run(session=None):
+    """Entry point for support mode."""
+    follow_manager.follow_target_loop()
+    support_ai.assist_party()
+    party_monitor.auto_join_party()

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,9 @@ from android_ms11.modes import (
     medic_mode,
     crafting_mode,
     whisper_mode,
+    support_mode,
+    bounty_farming_mode,
+    entertainer_mode,
 )
 
 DEFAULT_PROFILE_DIR = os.path.join("profiles", "runtime")
@@ -86,6 +89,9 @@ MODE_HANDLERS = {
     "medic": medic_mode.run,
     "crafting": crafting_mode.run,
     "whisper": whisper_mode.run,
+    "support": support_mode.run,
+    "bounty": bounty_farming_mode.run,
+    "entertainer": entertainer_mode.run,
 }
 
 

--- a/tests/test_support_mode.py
+++ b/tests/test_support_mode.py
@@ -1,0 +1,3 @@
+def test_support_mode_stub():
+    from android_ms11.modes import support_mode
+    support_mode.run()  # should execute without error


### PR DESCRIPTION
## Summary
- create `android_ms11/core` package with stub utilities
- add `support_mode`, `bounty_farming_mode`, and `entertainer_mode`
- wire new modes into `src.main`
- document new modes in README
- test the support mode stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f63db9ac883318e27746a79f840c5