### PR TITLE
Add max_loops parameter to support mode

### DIFF
--- a/android_ms11/modes/support_mode.py
+++ b/android_ms11/modes/support_mode.py
@@ -3,7 +3,7 @@
 from android_ms11.core import follow_manager, support_ai, party_monitor
 
 
-def run(session=None, max_loops: int = 1) -> None:
+def run(session=None, max_loops: int | None = None) -> None:
     """Entry point for support mode.
 
     Parameters
@@ -11,7 +11,8 @@ def run(session=None, max_loops: int = 1) -> None:
     session : optional
         Active session object providing configuration. May be ``None``.
     max_loops : int, optional
-        Number of cycles to run the support routines.
+        Number of cycles to run the support routines. If ``None``, run
+        indefinitely.
     """
 
     cfg = getattr(session, "config", {})
@@ -19,7 +20,12 @@ def run(session=None, max_loops: int = 1) -> None:
 
     print(f"[SUPPORT] Assisting leader {leader}")
 
-    for _ in range(max_loops):
+    loops = 0
+    while True:
         follow_manager.follow_target_loop()
         support_ai.assist_party()
         party_monitor.auto_join_party()
+
+        loops += 1
+        if max_loops is not None and loops >= max_loops:
+            break

--- a/tests/test_support_mode.py
+++ b/tests/test_support_mode.py
@@ -1,3 +1,6 @@
 def test_support_mode_stub():
     from android_ms11.modes import support_mode
-    support_mode.run()  # should execute without error
+    from types import SimpleNamespace
+
+    dummy_session = SimpleNamespace(config={})
+    support_mode.run(max_loops=1, session=dummy_session)  # should execute without error


### PR DESCRIPTION
## Summary
- allow running support mode indefinitely or a specified number of loops
- update unit test to pass dummy session and limit loops to one

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f8362cd0c833188eb0530a99de321