### PR TITLE
Register rls mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,7 @@ from android_ms11.modes import (
     support_mode,
     bounty_farming_mode,
     entertainer_mode,
+    rls_mode,
 )
 
 DEFAULT_PROFILE_DIR = os.path.join("profiles", "runtime")
@@ -92,6 +93,7 @@ MODE_HANDLERS = {
     "support": support_mode.run,
     "bounty": bounty_farming_mode.run,
     "entertainer": entertainer_mode.run,
+    "rls": rls_mode.run,
 }
 
 

--- a/tests/test_rls_mode.py
+++ b/tests/test_rls_mode.py
@@ -1,4 +1,12 @@
+import importlib
+
 from android_ms11.modes import rls_mode
+
+
+def test_mode_handlers_contains_rls():
+    import src.main as main
+    main_mod = importlib.reload(main)
+    assert main_mod.MODE_HANDLERS["rls"] is rls_mode.run
 
 
 def test_rls_mode_stub_runs_once(capsys):


### PR DESCRIPTION
## Summary
- register the rare loot scanner mode in MODE_HANDLERS
- test that the mode handler is correctly wired up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f9134e9108331b048eeef5606f954