### PR TITLE
Add partial test instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,11 @@ make test
 ```
 
 The `test` target installs the dependencies and then runs `pytest` for you.
+
+For quick checks during development you can run just the mode specific tests
+once the requirements are installed:
+
+```bash
+pytest -k support_mode -q
+pytest -k rls_mode -q
+```

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ This section walks through a fresh setup so you can try the project locally.
    pip install -r requirements.txt
    pytest
     # includes requests>=2.0, PyYAML, and pymongo>=3.0
+
+   # run a subset of the test suite
+   pytest -k support_mode -q
+   pytest -k rls_mode -q
    ```
 
 These steps should give you a working copy of Android MS11 and confidence


### PR DESCRIPTION
## Summary
- mention running a subset of tests in README
- show partial test commands in CONTRIBUTING guide

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest -k support_mode -q`
- `pytest -k rls_mode -q`


------
https://chatgpt.com/codex/tasks/task_b_685f94337ab08331b15b5df77ba9bc70