### PR TITLE
Add OCR buff detector stub

### DIFF
--- a/android_ms11/core/ocr_buff_detector.py
+++ b/android_ms11/core/ocr_buff_detector.py
@@ -1,0 +1,14 @@
+"""Stub OCR buff detector."""
+
+from __future__ import annotations
+
+
+def detect_buffs() -> list[str]:
+    """Return a list of missing buffs using OCR output."""
+    print("📸 Capturing screen for OCR...")
+    print("🔎 Running OCR to check active buffs...")
+    missing = ["Might", "Shield", "Haste"]
+    print(f"❌ Missing buffs detected: {', '.join(missing)}")
+    return missing
+
+__all__ = ["detect_buffs"]

--- a/android_ms11/tests/test_ocr_buff_detector.py
+++ b/android_ms11/tests/test_ocr_buff_detector.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from android_ms11.core.ocr_buff_detector import detect_buffs
+
+
+def test_detect_buffs_returns_list():
+    buffs = detect_buffs()
+    assert isinstance(buffs, list)
+    assert buffs
+    assert all(isinstance(b, str) for b in buffs)


### PR DESCRIPTION
## Summary
- add `ocr_buff_detector` stub to `android_ms11` core
- include new test for `detect_buffs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f9737e5708331b81f3e2e71cc730f