### PR TITLE
Add loops CLI option for rls mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -103,12 +103,20 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Android MS11 demo")
     parser.add_argument("--mode", type=str, help="Override session mode")
     parser.add_argument("--profile", type=str, help="Runtime profile name")
+    parser.add_argument(
+        "--loops",
+        type=int,
+        default=1,
+        help="Number of iterations when running rls mode",
+    )
     args = parser.parse_args(argv)
 
     config = load_config()
     profile = load_runtime_profile(args.profile) if args.profile else {}
 
     mode = args.mode or profile.get("mode") or config.get("default_mode", "medic")
+    if mode == "rls":
+        config["iterations"] = args.loops
 
     relay_enabled = config.get("enable_discord_relay", False)
     bot = None


### PR DESCRIPTION
## Summary
- extend `src/main.py` CLI to accept `--loops` argument
- forward the loops value to `rls_mode.run` via the config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686015743e1883319ce3989d9ffb098f