### PR TITLE
Improve RLS mode test

### DIFF
--- a/android_ms11/modes/rls_mode.py
+++ b/android_ms11/modes/rls_mode.py
@@ -5,11 +5,32 @@ from __future__ import annotations
 from android_ms11.core import loot_session, ocr_loot_scanner, rls_logic
 
 
-def run(config: dict | None = None, session=None) -> None:
-    """Run the rare loot scanner using ``config`` options."""
+def run(
+    config: dict | None = None,
+    session=None,
+    *,
+    loop_count: int | None = None,
+) -> None:
+    """Run the rare loot scanner using ``config`` options.
+
+    Parameters
+    ----------
+    config:
+        Optional configuration mapping. When provided, the ``iterations`` value
+        controls the number of scanning loops.
+    session:
+        Unused session object placeholder for API parity with other modes.
+    loop_count:
+        Explicit iteration count which overrides the ``iterations`` value in the
+        ``config`` mapping. This parameter allows tests or callers to bypass the
+        configuration file and specify a loop count directly.
+    """
 
     config = config or {}
-    iterations = int(config.get("iterations", 1))
+    if loop_count is not None:
+        iterations = int(loop_count)
+    else:
+        iterations = int(config.get("iterations", 1))
 
     print("[RLS] Starting rare loot scanner")
     for idx in range(iterations):

--- a/tests/test_rls_mode.py
+++ b/tests/test_rls_mode.py
@@ -1,16 +1,24 @@
 import importlib
 
 from android_ms11.modes import rls_mode
+from android_ms11.core import loot_session, ocr_loot_scanner, rls_logic
 
 
 def test_mode_handlers_contains_rls():
     import src.main as main
     main_mod = importlib.reload(main)
+    assert "rls" in main_mod.MODE_HANDLERS
     assert main_mod.MODE_HANDLERS["rls"] is rls_mode.run
 
 
-def test_rls_mode_stub_runs_once(capsys):
-    rls_mode.run()
-    output = capsys.readouterr().out.lower()
-    assert "rare loot" in output
+def test_rls_mode_logs_loot(monkeypatch):
+    loot_session._loot_log.clear()
+
+    monkeypatch.setattr(rls_logic, "choose_next_target", lambda: {"name": "Test"})
+    monkeypatch.setattr(ocr_loot_scanner, "scan_for_loot", lambda: ["Artifact"])
+    monkeypatch.setattr(loot_session, "export_log", lambda: "dummy.json")
+
+    rls_mode.run(loop_count=1)
+
+    assert any(entry["item"] == "Artifact" for entry in loot_session._loot_log)
 


### PR DESCRIPTION
## Summary
- extend `rls_mode.run` with `loop_count` keyword argument
- update RLS mode tests to check the handler and verify loot logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860185f90848331b694e998240174ae