### PR TITLE
Add profile loader utility

### DIFF
--- a/core/profile_loader.py
+++ b/core/profile_loader.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+PROFILE_DIR = Path(__file__).resolve().parents[1] / "profiles"
+
+REQUIRED_FIELDS = {
+    "support_target": str,
+    "preferred_trainers": dict,
+    "default_mode": str,
+    "skip_modes": list,
+    "farming_targets": list,
+}
+
+
+def load_profile(name: str) -> Dict[str, Any]:
+    """Return profile data for ``name`` or an empty dict if unavailable."""
+    path = PROFILE_DIR / f"{name}.json"
+    if not path.exists():
+        return {}
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    for field, expected_type in REQUIRED_FIELDS.items():
+        if field not in data:
+            raise ValueError(f"Missing required field: {field}")
+        if not isinstance(data[field], expected_type):
+            raise ValueError(f"{field} must be of type {expected_type.__name__}")
+
+    return data

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -1,0 +1,28 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.profile_loader import load_profile, PROFILE_DIR
+
+
+def test_load_profile_valid(tmp_path, monkeypatch):
+    data = {
+        "support_target": "Leader",
+        "preferred_trainers": {"medic": "trainer"},
+        "default_mode": "medic",
+        "skip_modes": ["crafting"],
+        "farming_targets": ["Bandit"]
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
+    prof = load_profile("demo")
+    assert prof == data
+
+
+def test_load_profile_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
+    prof = load_profile("missing")
+    assert prof == {}


### PR DESCRIPTION
## Summary
- create `core/profile_loader` module for loading game profiles
- validate required fields when loading profiles
- test profile loader for valid and missing profile files

## Testing
- `pytest tests/test_profile_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686025f85df883318e930ec1784c15c8