### PR TITLE
Implement session monitoring utilities

### DIFF
--- a/android_ms11/core/performance_tracker.py
+++ b/android_ms11/core/performance_tracker.py
@@ -1,0 +1,48 @@
+"""Track XP rate and loot accumulation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List, Dict, Any
+
+from src.utils.logger import log_performance_summary
+
+
+class PerformanceTracker:
+    """Record XP gains and loot drops during a session."""
+
+    def __init__(self) -> None:
+        self.start_time = datetime.now()
+        self.xp_gained = 0
+        self.loot: List[str] = []
+
+    # ------------------------------------------------------------------
+    def add_xp(self, amount: int) -> None:
+        """Increase the tracked XP by ``amount``."""
+        self.xp_gained += max(0, int(amount))
+
+    def add_loot(self, item: str) -> None:
+        """Record a loot ``item``."""
+        self.loot.append(item)
+
+    # ------------------------------------------------------------------
+    def xp_per_hour(self) -> float:
+        """Return the average XP gained per hour."""
+        elapsed = (datetime.now() - self.start_time).total_seconds() / 3600
+        return self.xp_gained / elapsed if elapsed > 0 else 0.0
+
+    def summary(self) -> Dict[str, Any]:
+        """Return a summary dictionary of performance stats."""
+        return {
+            "xp_rate": round(self.xp_per_hour(), 2),
+            "loot": len(self.loot),
+        }
+
+    def log_summary(self) -> Dict[str, Any]:
+        """Log the current performance summary and return it."""
+        stats = self.summary()
+        log_performance_summary(stats)
+        return stats
+
+
+__all__ = ["PerformanceTracker"]

--- a/android_ms11/core/session_monitor.py
+++ b/android_ms11/core/session_monitor.py
@@ -1,0 +1,43 @@
+"""Basic performance monitoring helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+from core.state_tracker import update_state, get_state
+from src.utils.logger import log_performance_summary
+
+
+def monitor_session(perf_metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Record ``perf_metrics`` and persist them using :mod:`core.state_tracker`.
+
+    Parameters
+    ----------
+    perf_metrics:
+        Dictionary containing performance values such as ``xp`` or ``loot``.
+
+    Returns
+    -------
+    dict
+        Updated state dictionary after persisting values.
+    """
+    loot = perf_metrics.get("loot")
+    xp = perf_metrics.get("xp")
+
+    updates: Dict[str, Any] = {}
+    if loot is not None:
+        updates["loot"] = loot
+    if xp is not None:
+        updates["xp"] = xp
+
+    if updates:
+        update_state(**updates)
+
+    stats = {
+        "xp_rate": perf_metrics.get("xp_rate", 0.0),
+        "loot": len(loot) if isinstance(loot, list) else 0,
+    }
+    log_performance_summary(stats)
+
+    return get_state()
+
+__all__ = ["monitor_session"]

--- a/android_ms11/tests/test_performance_tracker_module.py
+++ b/android_ms11/tests/test_performance_tracker_module.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from datetime import timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from android_ms11.core.performance_tracker import PerformanceTracker
+
+
+def test_tracker_rates_and_logging(monkeypatch, tmp_path):
+    from android_ms11.core import performance_tracker as pt_mod
+
+    logged = {}
+    monkeypatch.setattr(pt_mod, "log_performance_summary", lambda stats: logged.setdefault("stats", stats))
+
+    tracker = PerformanceTracker()
+    tracker.add_xp(100)
+    tracker.add_loot("Gold")
+    # Pretend the session has been running for 2 hours
+    tracker.start_time -= timedelta(hours=2)
+
+    rate = tracker.xp_per_hour()
+    assert 49.5 < rate < 50.5
+
+    summary = tracker.log_summary()
+    assert logged["stats"] == summary
+    assert summary["loot"] == 1

--- a/android_ms11/tests/test_session_monitor_module.py
+++ b/android_ms11/tests/test_session_monitor_module.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from android_ms11.core import session_monitor
+
+
+def test_monitor_session_updates_state(monkeypatch, tmp_path):
+    from core import state_tracker  # noqa: F401
+
+    state = {}
+    monkeypatch.setattr(session_monitor, "update_state", lambda **kw: state.update(kw))
+    monkeypatch.setattr(session_monitor, "get_state", lambda: state)
+
+    logged = {}
+    monkeypatch.setattr(session_monitor, "log_performance_summary", lambda stats, csv_path=str(tmp_path/"perf.csv"): logged.setdefault("stats", stats))
+
+    metrics = {"xp": 200, "xp_rate": 100.0, "loot": ["Gem"]}
+    result = session_monitor.monitor_session(metrics)
+
+    assert state["xp"] == 200
+    assert state["loot"] == ["Gem"]
+    assert result == state
+    assert logged["stats"]["xp_rate"] == 100.0


### PR DESCRIPTION
## Summary
- add PerformanceTracker for XP rate and loot
- add session_monitor to persist metrics via state_tracker
- test new performance tracking modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686044a0fe888331ae61a06875005094