### PR TITLE
Add smart mode session monitoring

### DIFF
--- a/tests/test_main_smart_monitor.py
+++ b/tests/test_main_smart_monitor.py
@@ -1,0 +1,49 @@
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core import profile_loader, state_tracker, mode_selector
+
+import src.main as main
+
+
+def test_smart_mode_invokes_monitor(monkeypatch):
+    main_mod = importlib.reload(main)
+
+    monkeypatch.setattr(main_mod, "load_config", lambda path=None: {})
+    monkeypatch.setattr(profile_loader, "load_profile", lambda name: {})
+    monkeypatch.setattr(state_tracker, "get_state", lambda: {})
+    monkeypatch.setattr(main_mod, "update_buff_state", lambda state: None)
+    monkeypatch.setattr(mode_selector, "select_mode", lambda profile, state: "combat")
+
+    class DummySession:
+        pass
+
+    monkeypatch.setattr(main_mod, "SessionManager", lambda mode: DummySession())
+
+    calls = {}
+
+    def combat_handler(cfg, session, profile=None):
+        calls["combat"] = True
+        return {"xp": 100}
+
+    def support_handler(cfg, session, profile=None):
+        calls["support"] = True
+        return {}
+
+    monkeypatch.setitem(main_mod.MODE_HANDLERS, "combat", combat_handler)
+    monkeypatch.setitem(main_mod.MODE_HANDLERS, "support", support_handler)
+
+    def fake_monitor(metrics):
+        calls["metrics"] = metrics
+        return {"mode": "support"}
+
+    monkeypatch.setattr(main_mod, "monitor_session", fake_monitor)
+
+    main_mod.main(["--smart"])
+
+    assert calls["combat"] is True
+    assert calls["metrics"] == {"xp": 100}
+    assert calls["support"] is True


### PR DESCRIPTION
## Summary
- import monitor_session in src/main
- call monitor_session after executing a mode when smart mode is enabled
- switch to a new mode if monitor_session returns one
- test new smart mode monitoring behavior

## Testing
- `pytest -q tests/test_main_smart_monitor.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68604e10b810833197d6c7509c010627