### PR TITLE
Implement android logging utils wrapper

### DIFF
--- a/android_ms11/utils/logging_utils.py
+++ b/android_ms11/utils/logging_utils.py
@@ -1,2 +1,34 @@
-"""Compatibility wrapper for :mod:`src.utils.logger`."""
-from src.utils.logger import *  # noqa: F401,F403
+"""Lightweight logging helpers used by Android MS11."""
+
+from __future__ import annotations
+
+import datetime
+import os
+
+try:
+    from src.utils.logger import log_event as _src_log_event
+except Exception:  # pragma: no cover - optional dependency
+    _src_log_event = None
+
+
+DEFAULT_LOG_PATH = os.path.join("logs", "session.log")
+
+
+def log_event(message: str, *, log_path: str = DEFAULT_LOG_PATH) -> str:
+    """Append ``message`` to ``log_path`` with a timestamp."""
+
+    if _src_log_event is not None:
+        return _src_log_event(message, log_path=log_path)
+
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    timestamp = datetime.datetime.now().isoformat()
+    try:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(f"{timestamp} | {message}\n")
+    except Exception as e:  # pragma: no cover - best effort logging
+        print(f"[logging_utils] Failed to log event: {e}")
+    return log_path
+
+
+__all__ = ["log_event"]
+

--- a/scripts/logic/trainer_navigator.py
+++ b/scripts/logic/trainer_navigator.py
@@ -18,7 +18,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 from utils.load_trainers import load_trainers
 from utils.get_trainer_location import get_trainer_location
 from src.training.trainer_visit import visit_trainer
-from src.utils.logger import log_event
+from android_ms11.utils.logging_utils import log_event
 
 # Default log files under the project's ``logs`` directory.
 DEFAULT_LOG_PATH = os.path.join("logs", "training_log.txt")


### PR DESCRIPTION
## Summary
- implement `log_event` in Android logger wrapper
- use wrapper in trainer navigator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686054e16920833190bdde84a570d8d9