### PR TITLE
Add session monitor and performance tracker

### DIFF
--- a/core/performance_tracker.py
+++ b/core/performance_tracker.py
@@ -1,0 +1,48 @@
+"""Simple performance tracking utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from utils.logging_utils import log_event
+
+
+class PerformanceTracker:
+    """Track XP gain rate and loot during a session."""
+
+    def __init__(self) -> None:
+        self.start_time = datetime.now()
+        self.xp_gained = 0
+        self.loot: List[str] = []
+
+    # -----------------------------------------------------
+    def add_xp(self, amount: int) -> None:
+        """Increase tracked XP by ``amount``."""
+        self.xp_gained += max(0, int(amount))
+
+    def add_loot(self, item: str) -> None:
+        """Record a loot ``item``."""
+        self.loot.append(item)
+
+    # -----------------------------------------------------
+    def xp_per_hour(self) -> float:
+        """Return the average XP gained per hour."""
+        elapsed = (datetime.now() - self.start_time).total_seconds() / 3600
+        return self.xp_gained / elapsed if elapsed > 0 else 0.0
+
+    def summary(self) -> Dict[str, Any]:
+        """Return a dictionary summary of stats."""
+        return {
+            "xp_rate": round(self.xp_per_hour(), 2),
+            "loot": len(self.loot),
+        }
+
+    def log_summary(self) -> Dict[str, Any]:
+        """Log a summary event and return the stats."""
+        stats = self.summary()
+        log_event(f"XP/hr: {stats['xp_rate']} | Loot items: {stats['loot']}")
+        return stats
+
+
+__all__ = ["PerformanceTracker"]

--- a/core/session_monitor.py
+++ b/core/session_monitor.py
@@ -1,0 +1,66 @@
+"""Track session metrics and adjust mode if needed."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from core import state_tracker
+from utils.logging_utils import log_event
+
+FATIGUE_THRESHOLD = 3
+LOW_XP_RATE = 20.0
+HIGH_XP_RATE = 200.0
+
+
+def monitor_session(perf_metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Record metrics to :mod:`core.state_tracker` and update mode.
+
+    Parameters
+    ----------
+    perf_metrics:
+        Dictionary with optional ``xp``, ``loot`` and ``xp_rate`` keys.
+
+    Returns
+    -------
+    dict
+        Updated state dictionary after applying fatigue logic and mode selection.
+    """
+    state = state_tracker.get_state()
+    xp = perf_metrics.get("xp")
+    loot = perf_metrics.get("loot")
+    xp_rate = float(perf_metrics.get("xp_rate", 0.0))
+
+    fatigue = int(state.get("fatigue", 0))
+    if xp_rate < LOW_XP_RATE:
+        fatigue += 1
+    else:
+        fatigue = max(fatigue - 1, 0)
+
+    updates: Dict[str, Any] = {"fatigue": fatigue}
+    if xp is not None:
+        updates["xp"] = xp
+    if loot is not None:
+        updates["loot"] = loot
+
+    if fatigue >= FATIGUE_THRESHOLD:
+        mode = "support"
+    elif xp_rate < 50:
+        mode = "quest"
+    elif xp_rate > HIGH_XP_RATE:
+        mode = "combat"
+    else:
+        mode = state.get("mode")
+
+    if mode is not None:
+        updates["mode"] = mode
+
+    state_tracker.update_state(**updates)
+
+    log_event(
+        f"Session summary - XP/hr: {xp_rate:.2f}, Loot: {len(loot) if isinstance(loot, list) else 0}, Fatigue: {fatigue}, Mode: {mode}"
+    )
+
+    return state_tracker.get_state()
+
+
+__all__ = ["monitor_session"]


### PR DESCRIPTION
## Summary
- add new core session monitor with fatigue logic
- add performance tracker class for XP rate and loot
- log session metrics and summaries using `log_event`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_686061c5647483319a00a89b4ffb1c65