### PR TITLE
Add lightweight logging helper

### DIFF
--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -1,0 +1,14 @@
+"""Lightweight logging helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def log_event(message: str) -> None:
+    """Print ``message`` with an ISO timestamp in UTC."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{timestamp}] {message}")
+
+
+__all__ = ["log_event"]


### PR DESCRIPTION
## Summary
- add `log_event` for UTC-stamped output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6860640fcdf08331b766ac3ee9675903