### PR TITLE
Update smart mode monitoring

### DIFF
--- a/tests/test_main_smart_monitor.py
+++ b/tests/test_main_smart_monitor.py
@@ -27,7 +27,7 @@ def test_smart_mode_invokes_monitor(monkeypatch):
 
     def combat_handler(cfg, session, profile=None):
         calls["combat"] = True
-        return {"xp": 100}
+        return {"xp": 100, "xp_rate": 50.0}
 
     def support_handler(cfg, session, profile=None):
         calls["support"] = True
@@ -45,5 +45,5 @@ def test_smart_mode_invokes_monitor(monkeypatch):
     main_mod.main(["--smart"])
 
     assert calls["combat"] is True
-    assert calls["metrics"] == {"xp": 100}
+    assert calls["metrics"] == {"xp": 100, "xp_rate": 50.0}
     assert calls["support"] is True


### PR DESCRIPTION
## Summary
- import monitor_session from `core.session_monitor`
- track handler results as `session_metrics`
- when using `--smart`, only monitor if `xp_rate` exists
- print a Smart Switch message and rerun handler on mode change
- update smart monitoring test to reflect new logic

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68606554d2c4833181f42483c19fa301