### PR TITLE
Add mode scheduler utility

### DIFF
--- a/core/mode_scheduler.py
+++ b/core/mode_scheduler.py
@@ -1,0 +1,34 @@
+"""Utilities for scheduling runtime modes."""
+
+from __future__ import annotations
+
+from typing import Mapping, Any, Sequence
+
+
+def get_next_mode(profile: Mapping[str, Any], state: Mapping[str, Any]) -> str:
+    """Return the next mode in ``profile['mode_sequence']``.
+
+    Parameters
+    ----------
+    profile:
+        Mapping containing a ``mode_sequence`` list and optional ``default_mode``.
+    state:
+        Mapping providing the current ``mode`` value.
+    """
+    sequence: Sequence[str] = profile.get("mode_sequence", [])
+    if not sequence:
+        return profile.get("default_mode", "")
+
+    default_mode = profile.get("default_mode", sequence[0])
+    current = state.get("mode", default_mode)
+
+    try:
+        idx = sequence.index(current)
+        next_idx = (idx + 1) % len(sequence)
+    except ValueError:
+        next_idx = 0
+
+    return sequence[next_idx]
+
+
+__all__ = ["get_next_mode"]

--- a/tests/test_mode_scheduler.py
+++ b/tests/test_mode_scheduler.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.mode_scheduler import get_next_mode
+
+
+def test_get_next_mode_wraparound():
+    profile = {"default_mode": "quest", "mode_sequence": ["quest", "combat", "crafting"]}
+    state = {"mode": "combat"}
+    assert get_next_mode(profile, state) == "crafting"
+    assert get_next_mode(profile, {"mode": "crafting"}) == "quest"
+
+
+def test_get_next_mode_missing_current():
+    profile = {"default_mode": "quest", "mode_sequence": ["quest", "combat", "crafting"]}
+    state = {"mode": "unknown"}
+    assert get_next_mode(profile, state) == "quest"
+
+
+def test_get_next_mode_no_sequence():
+    profile = {"default_mode": "quest"}
+    state = {"mode": "quest"}
+    assert get_next_mode(profile, state) == "quest"


### PR DESCRIPTION
## Summary
- implement `core/mode_scheduler.get_next_mode`
- add unit tests for scheduler logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68606e4809548331a9561d83d8d50813