### PR TITLE
Update main loop handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,7 @@ python src/main.py --mode rls
 ```
 
 ### RLS Mode
-Rare Loot Scanner mode monitors loot messages and records rare item drops. Use the ``--loops`` option to control how many scans run:
-
-```bash
-python src/main.py --mode rls --loops 2
-```
+Rare Loot Scanner mode monitors loot messages and records rare item drops. The number of scans is controlled by the ``iterations`` value in ``config/config.json``.
 
 Runtime profiles stored in `profiles/runtime/` let you bundle these
 settings together. Use the ``--profile`` option to load one:


### PR DESCRIPTION
## Summary
- swap `--loops` CLI option for `--loop` flag
- implement runtime loop that monitors fatigue and switches modes when needed
- document changes for rare loot scanning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860703f87e083319e6ea7f0b4fd936a