### PR TITLE
Add fatigue and mode switch logging

### DIFF
--- a/core/session_monitor.py
+++ b/core/session_monitor.py
@@ -30,7 +30,9 @@ def monitor_session(perf_metrics: Dict[str, Any]) -> Dict[str, Any]:
     loot = perf_metrics.get("loot")
     xp_rate = float(perf_metrics.get("xp_rate", 0.0))
 
-    fatigue = int(state.get("fatigue_level", 0))
+    prev_fatigue = int(state.get("fatigue_level", 0))
+    prev_mode = state.get("mode")
+    fatigue = prev_fatigue
     if xp_rate < LOW_XP_RATE:
         fatigue += 1
         mode = "bounty_mode"
@@ -40,6 +42,9 @@ def monitor_session(perf_metrics: Dict[str, Any]) -> Dict[str, Any]:
     else:
         mode = state.get("mode")
 
+    crossed_threshold = prev_fatigue < FATIGUE_THRESHOLD <= fatigue
+    mode_changed = prev_mode != mode
+
     updates: Dict[str, Any] = {"fatigue_level": fatigue}
     if xp is not None:
         updates["xp"] = xp
@@ -48,6 +53,11 @@ def monitor_session(perf_metrics: Dict[str, Any]) -> Dict[str, Any]:
     updates["mode"] = mode
 
     state_tracker.update_state(**updates)
+
+    if crossed_threshold or mode_changed:
+        log_event(
+            f"Fatigue detected in mode: {prev_mode}. Switching to: {mode}"
+        )
 
     log_event(
         f"Session summary - XP/hr: {xp_rate:.2f}, Loot: {len(loot) if isinstance(loot, list) else 0}, Fatigue: {fatigue}, Mode: {mode}"


### PR DESCRIPTION
## Summary
- log events on fatigue threshold and mode switches in `session_monitor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686073481b6883319d486f129f164629