### PR TITLE
Add repeat mode loop flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,20 @@ Example profile snippet:
 This setup cycles through questing, crafting, and healing whenever fatigue rises
 above 50 while ``--loop`` is active.
 
+### 🔁 Repeat Mode
+
+To continuously run a single mode (like entertainer or farming), use:
+
+```bash
+python src/main.py --mode entertainer --repeat
+```
+
+You can also set a rest interval (in seconds) between loops:
+
+```bash
+python src/main.py --mode entertainer --repeat --rest 30
+```
+
 ## State Tracking and Profiles
 
 The `core.state_tracker` module persists simple game state between runs.

--- a/core/repeat_utils.py
+++ b/core/repeat_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import time
+from typing import Callable, Mapping, Any
+
+from utils.logging_utils import log_event
+
+
+def run_repeating_mode(
+    mode: str,
+    runner: Callable[[], Mapping[str, Any]],
+    rest_time: int = 10,
+) -> None:
+    """Run ``runner`` continuously with a rest between iterations."""
+    log_event(f"Repeat mode activated for: {mode}")
+    while True:
+        runner()
+        log_event(
+            f"Mode {mode} completed. Resting {rest_time} seconds before restarting..."
+        )
+        time.sleep(rest_time)
+
+
+__all__ = ["run_repeating_mode"]

--- a/tests/test_repeat_mode.py
+++ b/tests/test_repeat_mode.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.main import parse_args
+
+
+def test_repeat_flag_sets_loop(monkeypatch):
+    test_args = ["src/main.py", "--mode", "entertainer", "--repeat"]
+    monkeypatch.setattr("sys.argv", test_args)
+    args = parse_args()
+    assert args.repeat is True
+


### PR DESCRIPTION
## Summary
- add `--repeat` flag for running one mode forever
- allow specifying `--rest` interval between loops
- factor CLI args to `parse_args()` and add `run_mode()` helper
- implement repeat loop helper in `core/repeat_utils`
- document Repeat Mode usage in README
- test repeat argument parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860784845e88331bb1c70a08bddb576