### PR TITLE
Add trainer flag and loop limit

### DIFF
--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.main import parse_args
+
+
+def test_max_loops_flag(monkeypatch):
+    test_args = ["src/main.py", "--mode", "support", "--max_loops", "5"]
+    monkeypatch.setattr("sys.argv", test_args)
+    args = parse_args()
+    assert args.max_loops == 5
+
+
+def test_train_flag(monkeypatch):
+    test_args = ["src/main.py", "--train"]
+    monkeypatch.setattr("sys.argv", test_args)
+    args = parse_args()
+    assert args.train is True
+
+
+def test_auto_train_alias(monkeypatch):
+    test_args = ["src/main.py", "--auto_train"]
+    monkeypatch.setattr("sys.argv", test_args)
+    args = parse_args()
+    assert args.train is True


### PR DESCRIPTION
## Summary
- extend CLI with `--max_loops` and `--train/--auto_train`
- route `max_loops` to mode handlers
- optionally run trainer visits after each iteration
- provide tests for new flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68607d54bcf083318932fb74f03ff0cc