### PR TITLE
Add farming_target and auto_train to profile loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,19 @@ Example profile:
   "preferred_trainers": {"medic": "trainer"},
   "default_mode": "medic",
   "skip_modes": ["crafting"],
-  "farming_targets": ["Bandit"]
+  "farming_targets": ["Bandit"],
+  "farming_target": {
+    "planet": "Naboo",
+    "city": "Theed",
+    "hotspot": "Cantina"
+  },
+  "auto_train": false
 }
 ```
+
+`farming_target` defines the planet, city and hotspot for farming sessions.
+Setting `auto_train` to `true` will automatically check trainers after each
+loop.
 
 ```python
 from core import profile_loader

--- a/core/profile_loader.py
+++ b/core/profile_loader.py
@@ -19,6 +19,8 @@ REQUIRED_FIELDS = {
 OPTIONAL_FIELDS = {
     "mode_sequence": list,
     "fatigue_threshold": int,
+    "farming_target": dict,
+    "auto_train": bool,
 }
 
 
@@ -38,9 +40,21 @@ def load_profile(name: str) -> Dict[str, Any]:
             raise ValueError(f"{field} must be of type {expected_type.__name__}")
 
     for field, expected_type in OPTIONAL_FIELDS.items():
-        if field in data and not isinstance(data[field], expected_type):
-            raise ValueError(
-                f"{field} must be of type {expected_type.__name__}"
-            )
+        if field in data:
+            if not isinstance(data[field], expected_type):
+                raise ValueError(
+                    f"{field} must be of type {expected_type.__name__}"
+                )
+            if field == "farming_target":
+                required_keys = {"planet", "city", "hotspot"}
+                missing = required_keys - data[field].keys()
+                if missing:
+                    raise ValueError(
+                        f"farming_target missing keys: {', '.join(sorted(missing))}"
+                    )
+                if not all(isinstance(data[field][k], str) for k in required_keys):
+                    raise ValueError("farming_target values must be strings")
+
+    data.setdefault("auto_train", False)
 
     return data

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -14,6 +15,12 @@ def test_load_profile_valid(tmp_path, monkeypatch):
         "default_mode": "medic",
         "skip_modes": ["crafting"],
         "farming_targets": ["Bandit"],
+        "farming_target": {
+            "planet": "Naboo",
+            "city": "Theed",
+            "hotspot": "Cantina",
+        },
+        "auto_train": True,
         "mode_sequence": ["medic", "quest"],
         "fatigue_threshold": 5,
     }
@@ -22,6 +29,45 @@ def test_load_profile_valid(tmp_path, monkeypatch):
     monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
     prof = load_profile("demo")
     assert prof == data
+
+
+def test_auto_train_default(tmp_path, monkeypatch):
+    data = {
+        "support_target": "Leader",
+        "preferred_trainers": {"medic": "trainer"},
+        "default_mode": "medic",
+        "skip_modes": ["crafting"],
+        "farming_targets": ["Bandit"],
+        "farming_target": {
+            "planet": "Naboo",
+            "city": "Theed",
+            "hotspot": "Cantina",
+        },
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
+    prof = load_profile("demo")
+    assert prof["auto_train"] is False
+
+
+def test_invalid_farming_target(tmp_path, monkeypatch):
+    data = {
+        "support_target": "Leader",
+        "preferred_trainers": {"medic": "trainer"},
+        "default_mode": "medic",
+        "skip_modes": ["crafting"],
+        "farming_targets": ["Bandit"],
+        "farming_target": {
+            "planet": "Naboo",
+            "city": "Theed",
+        },
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
+    with pytest.raises(ValueError):
+        load_profile("demo")
 
 
 def test_load_profile_missing(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- extend profile loader with `farming_target` and `auto_train`
- validate `farming_target` structure and default `auto_train`
- document new profile settings in README
- expand profile loader tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686083378cd083318cfa7ead5dcefccb