### PR TITLE
Add waypoint verifier utility

### DIFF
--- a/modules/travel/trainer_travel.py
+++ b/modules/travel/trainer_travel.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 
 from scripts.travel import shuttle
 from src.movement.movement_profiles import walk_to_coords
+from utils.waypoint_verifier import verify_waypoint
 
 
 DEFAULT_START_CITY = "mos_eisley"
@@ -63,4 +64,5 @@ def travel_to_trainer(profession: str, trainer_data: Dict[str, dict], agent=None
     )
 
     walk_to_coords(agent, dest_x, dest_y)
+    verify_waypoint((dest_x, dest_y))
     return result

--- a/tests/test_waypoint_verifier.py
+++ b/tests/test_waypoint_verifier.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.waypoint_verifier import verify_waypoint
+
+
+def test_verify_waypoint_stable(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_detect():
+        calls["count"] += 1
+        return (100, 100)
+
+    monkeypatch.setattr("utils.waypoint_verifier._detect_position", fake_detect)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+
+    assert verify_waypoint((100, 100)) is True
+    assert calls["count"] == 2
+
+
+def test_verify_waypoint_moved(monkeypatch):
+    positions = [(100, 100), (105, 100)]
+
+    def fake_detect():
+        return positions.pop(0)
+
+    monkeypatch.setattr("utils.waypoint_verifier._detect_position", fake_detect)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+
+    assert verify_waypoint((100, 100)) is False
+

--- a/utils/waypoint_verifier.py
+++ b/utils/waypoint_verifier.py
@@ -1,0 +1,48 @@
+"""Helpers for verifying that the player hasn't been moved away from a waypoint."""
+
+from __future__ import annotations
+
+import time
+from typing import Tuple
+
+import re
+from src.vision import screen_text
+
+_COORD_RE = re.compile(r"(-?\d+)\s*[,:]?\s*(-?\d+)")
+
+
+def _detect_position() -> Coords:
+    """Return the player's coordinates parsed from the screen."""
+    text = screen_text()
+    match = _COORD_RE.search(text)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+    return 0, 0
+
+Coords = Tuple[int, int]
+
+
+def _distance(a: Coords, b: Coords) -> float:
+    """Return Euclidean distance between two coordinate pairs."""
+    return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2) ** 0.5
+
+
+def verify_waypoint(coords: Coords, delay: float = 1.0) -> bool:
+    """Return ``True`` if the player remains near ``coords`` after ``delay`` seconds."""
+
+    start = _detect_position()
+    start_dist = _distance(start, coords)
+
+    time.sleep(delay)
+
+    end = _detect_position()
+    end_dist = _distance(end, coords)
+
+    if end_dist > start_dist:
+        print(
+            f"[WaypointVerifier] Player moved from {start} to {end}; distance increased."
+        )
+        return False
+
+    print(f"[WaypointVerifier] Position stable at {start}.")
+    return True


### PR DESCRIPTION
## Summary
- add `utils.waypoint_verifier` to detect relocation from screen text
- verify trainer arrival coordinates with the new helper
- test waypoint stability logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6860870011208331a4c092248113fe69