### PR TITLE
Enable auto_train profile option

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -190,6 +190,7 @@ def main(argv: list[str] | None = None) -> None:
 
     config = load_config()
     profile = profile_loader.load_profile(args.profile) if args.profile else {}
+    args.train = args.train or profile.get("auto_train", False)
 
     if args.smart:
         state = state_tracker.get_state()

--- a/tests/test_main_auto_train.py
+++ b/tests/test_main_auto_train.py
@@ -1,0 +1,43 @@
+import argparse
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import src.main as main
+from core import profile_loader, state_tracker
+
+
+def test_profile_auto_train_sets_flag(monkeypatch):
+    main_mod = reload(main)
+
+    captured = {}
+
+    def fake_parse_args(argv=None):
+        ns = argparse.Namespace(
+            mode="combat",
+            profile="demo",
+            smart=False,
+            loop=False,
+            repeat=False,
+            rest=10,
+            max_loops=None,
+            train=False,
+        )
+        captured["args"] = ns
+        return ns
+
+    monkeypatch.setattr(main_mod, "parse_args", fake_parse_args)
+    monkeypatch.setattr(main_mod, "load_config", lambda path=None: {})
+    monkeypatch.setattr(profile_loader, "load_profile", lambda name: {"auto_train": True})
+    monkeypatch.setattr(state_tracker, "reset_state", lambda: None)
+    monkeypatch.setattr(main_mod, "SessionManager", lambda mode: object())
+    monkeypatch.setattr(main_mod, "run_mode", lambda *a, **k: {})
+    monkeypatch.setattr(main_mod, "check_and_train_skills", lambda *a, **k: None)
+    monkeypatch.setattr(main_mod, "MovementAgent", lambda session=None: None)
+    monkeypatch.setattr(main_mod, "monitor_session", lambda *a, **k: {})
+
+    main_mod.main([])
+
+    assert captured["args"].train is True


### PR DESCRIPTION
## Summary
- respect `auto_train` profile setting when initializing the CLI options
- test auto-train flag from profile

## Testing
- `pytest tests/test_main_auto_train.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68608c27fae0833183186269f121bad3