### PR TITLE
Add farming_target CLI override

### DIFF
--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -25,3 +25,15 @@ def test_auto_train_alias(monkeypatch):
     monkeypatch.setattr("sys.argv", test_args)
     args = parse_args()
     assert args.train is True
+
+
+def test_farming_target_parsing(monkeypatch):
+    json_arg = '{"planet": "Tatooine", "city": "Mos Eisley", "hotspot": "Cantina"}'
+    test_args = ["src/main.py", "--farming_target", json_arg]
+    monkeypatch.setattr("sys.argv", test_args)
+    args = parse_args()
+    assert args.farming_target == {
+        "planet": "Tatooine",
+        "city": "Mos Eisley",
+        "hotspot": "Cantina",
+    }

--- a/tests/test_main_farming_target.py
+++ b/tests/test_main_farming_target.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+import sys
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import src.main as main
+from core import profile_loader, state_tracker
+
+
+def test_cli_farming_target_overrides_profile(monkeypatch):
+    main_mod = reload(main)
+    cli_target = {"planet": "Dantooine", "city": "Mining", "hotspot": "Cave"}
+
+    def fake_parse_args(argv=None):
+        ns = argparse.Namespace(
+            mode="combat",
+            profile="demo",
+            smart=False,
+            loop=False,
+            repeat=False,
+            rest=10,
+            max_loops=None,
+            train=False,
+            farming_target=cli_target,
+        )
+        return ns
+
+    monkeypatch.setattr(main_mod, "parse_args", fake_parse_args)
+    base_profile = {"farming_target": {"planet": "Naboo", "city": "Theed", "hotspot": "Cantina"}}
+    monkeypatch.setattr(profile_loader, "load_profile", lambda name: base_profile.copy())
+    monkeypatch.setattr(state_tracker, "reset_state", lambda: None)
+    monkeypatch.setattr(main_mod, "load_config", lambda path=None: {})
+    monkeypatch.setattr(main_mod, "SessionManager", lambda mode: object())
+    monkeypatch.setattr(main_mod, "check_and_train_skills", lambda *a, **k: None)
+    monkeypatch.setattr(main_mod, "MovementAgent", lambda session=None: None)
+    monkeypatch.setattr(main_mod, "monitor_session", lambda *a, **k: {})
+
+    captured = {}
+
+    def fake_run_mode(mode, session, profile, config, *, max_loops=None):
+        captured["profile"] = profile
+        return {}
+
+    monkeypatch.setattr(main_mod, "run_mode", fake_run_mode)
+
+    main_mod.main([])
+
+    assert captured["profile"]["farming_target"] == cli_target


### PR DESCRIPTION
## Summary
- add `--farming_target` CLI option
- parse JSON value to dict
- allow CLI value to override profile farming target
- test parsing logic
- test CLI override behavior

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68608e40d9c48331a325bb9f7e15fff8