### PR TITLE
Add location and waypoint helpers

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,14 +1,16 @@
 """Core runtime utilities."""
 
+from .location_selector import locate_hotspot, travel_to_target
+from .profession_leveler import ProfessionLeveler
 from .trainer_ocr import (
-    preprocess_image,
     extract_text_from_trainer_region,
     get_untrained_skills_from_text,
+    preprocess_image,
     scan_and_detect_untrained_skills,
 )
-from .trainer_scanner import scan_trainer_skills, TrainerScanner
+from .trainer_scanner import TrainerScanner, scan_trainer_skills
 from .travel_manager import TravelManager
-from .profession_leveler import ProfessionLeveler
+from .waypoint_verifier import verify_waypoint_stability
 
 __all__ = [
     "preprocess_image",
@@ -19,4 +21,7 @@ __all__ = [
     "TrainerScanner",
     "TravelManager",
     "ProfessionLeveler",
+    "travel_to_target",
+    "locate_hotspot",
+    "verify_waypoint_stability",
 ]

--- a/core/location_selector.py
+++ b/core/location_selector.py
@@ -1,0 +1,36 @@
+"""High level helpers for selecting travel targets."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Tuple
+
+from modules.travel.location_selector import select_target
+from src.movement.movement_profiles import walk_to_coords
+
+# Simplified hotspot coordinate lookup table.
+HOTSPOTS: dict[str, dict[str, dict[str, Tuple[int, int]]]] = {
+    "tatooine": {
+        "mos_eisley": {"cantina": (3520, -4800)},
+    },
+    "dantooine": {"mining": {"cave": (50, 75)}},
+}
+
+
+def locate_hotspot(planet: str, city: str, hotspot: str) -> Optional[Tuple[int, int]]:
+    """Return coordinates for ``hotspot`` in ``city`` on ``planet`` if known."""
+    return HOTSPOTS.get(planet.lower(), {}).get(city.lower(), {}).get(hotspot.lower())
+
+
+def travel_to_target(target: Mapping[str, str], agent=None) -> Optional[dict]:
+    """Travel to the desired target and walk to its hotspot if provided."""
+    planet = target.get("planet", "tatooine")
+    city = target.get("city", "mos_eisley")
+    hotspot = target.get("hotspot")
+
+    dest = select_target(planet, city, agent=agent)
+
+    if hotspot:
+        coords = locate_hotspot(planet, city, hotspot)
+        if coords:
+            walk_to_coords(agent, coords[0], coords[1])
+    return dest

--- a/core/waypoint_verifier.py
+++ b/core/waypoint_verifier.py
@@ -1,0 +1,43 @@
+"""Helpers for verifying that the player remains at a waypoint."""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Tuple
+
+from src.vision import screen_text
+
+_COORD_RE = re.compile(r"(-?\d+)\s*[,:]?\s*(-?\d+)")
+
+Coords = Tuple[int, int]
+
+
+def _detect_position() -> Coords:
+    """Return the player's coordinates parsed from the screen."""
+    text = screen_text()
+    match = _COORD_RE.search(text)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+    return 0, 0
+
+
+def _distance(a: Coords, b: Coords) -> float:
+    """Return Euclidean distance between two coordinate pairs."""
+    return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2) ** 0.5
+
+
+def verify_waypoint_stability(coords: Coords, delay: float = 1.0) -> bool:
+    """Return ``True`` if the player stays near ``coords`` after ``delay`` seconds."""
+    start = _detect_position()
+    start_dist = _distance(start, coords)
+    time.sleep(delay)
+    end = _detect_position()
+    end_dist = _distance(end, coords)
+    if end_dist > start_dist:
+        print(
+            f"[WaypointVerifier] Player moved from {start} to {end}; distance increased."
+        )
+        return False
+    print(f"[WaypointVerifier] Position stable at {start}.")
+    return True

--- a/modules/travel/trainer_travel.py
+++ b/modules/travel/trainer_travel.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
+from core.waypoint_verifier import verify_waypoint_stability
 from scripts.travel import shuttle
 from src.movement.movement_profiles import walk_to_coords
-from utils.waypoint_verifier import verify_waypoint
-
 
 DEFAULT_START_CITY = "mos_eisley"
 DEFAULT_START_PLANET = "tatooine"
@@ -64,5 +63,5 @@ def travel_to_trainer(profession: str, trainer_data: Dict[str, dict], agent=None
     )
 
     walk_to_coords(agent, dest_x, dest_y)
-    verify_waypoint((dest_x, dest_y))
+    verify_waypoint_stability((dest_x, dest_y))
     return result

--- a/tests/test_core_location_selector.py
+++ b/tests/test_core_location_selector.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core import location_selector
+
+
+def test_travel_to_target_invokes_helpers(monkeypatch):
+    calls = []
+
+    def fake_select(planet, city, agent=None):
+        calls.append(("select", planet, city))
+        return {"city": city}
+
+    def fake_walk(agent, x, y):
+        calls.append(("walk", x, y))
+
+    monkeypatch.setattr(location_selector, "select_target", fake_select)
+    monkeypatch.setattr(location_selector, "locate_hotspot", lambda *a, **k: (1, 2))
+    monkeypatch.setattr(location_selector, "walk_to_coords", fake_walk)
+
+    target = {"planet": "corellia", "city": "coronet", "hotspot": "cantina"}
+    location_selector.travel_to_target(target, agent="A")
+
+    assert calls == [("select", "corellia", "coronet"), ("walk", 1, 2)]
+
+
+def test_travel_to_target_no_coords(monkeypatch):
+    calls = []
+
+    def fake_select(planet, city, agent=None):
+        calls.append(("select", planet, city))
+        return {"city": city}
+
+    monkeypatch.setattr(location_selector, "select_target", fake_select)
+    monkeypatch.setattr(location_selector, "locate_hotspot", lambda *a, **k: None)
+    monkeypatch.setattr(
+        location_selector, "walk_to_coords", lambda *a, **k: calls.append(("walk",))
+    )
+
+    target = {"planet": "corellia", "city": "coronet"}
+    location_selector.travel_to_target(target, agent="A")
+
+    assert calls == [("select", "corellia", "coronet")]

--- a/tests/test_travel_to_trainer.py
+++ b/tests/test_travel_to_trainer.py
@@ -11,7 +11,14 @@ from src.movement import movement_profiles
 def test_travel_to_trainer_invokes_navigation(monkeypatch):
     calls = []
 
-    def fake_nav(city, agent, start_city="mos_eisley", start_planet="tatooine", dest_planet=None, shuttle_file=None):
+    def fake_nav(
+        city,
+        agent,
+        start_city="mos_eisley",
+        start_planet="tatooine",
+        dest_planet=None,
+        shuttle_file=None,
+    ):
         calls.append(("nav", city, start_city, start_planet, dest_planet))
         return "NAV"
 
@@ -20,11 +27,23 @@ def test_travel_to_trainer_invokes_navigation(monkeypatch):
 
     monkeypatch.setattr(shuttle, "navigate_to", fake_nav)
     monkeypatch.setattr(trainer_travel, "walk_to_coords", fake_walk)
-    monkeypatch.setattr(shuttle, "plan_route", lambda *a, **k: [{"city": "mos_eisley"}, {"city": "coronet"}])
+    monkeypatch.setattr(
+        trainer_travel, "verify_waypoint_stability", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        shuttle,
+        "plan_route",
+        lambda *a, **k: [{"city": "mos_eisley"}, {"city": "coronet"}],
+    )
 
     data = {
         "artisan": [
-            {"planet": "tatooine", "city": "mos_eisley", "name": "Trainer", "coords": [1, 2]}
+            {
+                "planet": "tatooine",
+                "city": "mos_eisley",
+                "name": "Trainer",
+                "coords": [1, 2],
+            }
         ]
     }
     result = trainer_travel.travel_to_trainer("artisan", data, agent="A")
@@ -39,11 +58,23 @@ def test_travel_to_trainer_invokes_navigation(monkeypatch):
 def test_travel_to_trainer_logs_route(monkeypatch, capsys):
     monkeypatch.setattr(shuttle, "navigate_to", lambda *a, **k: None)
     monkeypatch.setattr(trainer_travel, "walk_to_coords", lambda *a, **k: None)
-    monkeypatch.setattr(shuttle, "plan_route", lambda *a, **k: [{"city": "mos_eisley"}, {"city": "anchorhead"}])
+    monkeypatch.setattr(
+        trainer_travel, "verify_waypoint_stability", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        shuttle,
+        "plan_route",
+        lambda *a, **k: [{"city": "mos_eisley"}, {"city": "anchorhead"}],
+    )
 
     data = {
         "brawler": [
-            {"planet": "tatooine", "city": "anchorhead", "name": "Brawl", "coords": [5, 6]}
+            {
+                "planet": "tatooine",
+                "city": "anchorhead",
+                "name": "Brawl",
+                "coords": [5, 6],
+            }
         ]
     }
     trainer_travel.travel_to_trainer("brawler", data, agent="A")

--- a/tests/test_waypoint_verifier.py
+++ b/tests/test_waypoint_verifier.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from utils.waypoint_verifier import verify_waypoint
+from core.waypoint_verifier import verify_waypoint_stability
 
 
 def test_verify_waypoint_stable(monkeypatch):
@@ -13,10 +13,10 @@ def test_verify_waypoint_stable(monkeypatch):
         calls["count"] += 1
         return (100, 100)
 
-    monkeypatch.setattr("utils.waypoint_verifier._detect_position", fake_detect)
+    monkeypatch.setattr("core.waypoint_verifier._detect_position", fake_detect)
     monkeypatch.setattr("time.sleep", lambda *_: None)
 
-    assert verify_waypoint((100, 100)) is True
+    assert verify_waypoint_stability((100, 100)) is True
     assert calls["count"] == 2
 
 
@@ -26,8 +26,7 @@ def test_verify_waypoint_moved(monkeypatch):
     def fake_detect():
         return positions.pop(0)
 
-    monkeypatch.setattr("utils.waypoint_verifier._detect_position", fake_detect)
+    monkeypatch.setattr("core.waypoint_verifier._detect_position", fake_detect)
     monkeypatch.setattr("time.sleep", lambda *_: None)
 
-    assert verify_waypoint((100, 100)) is False
-
+    assert verify_waypoint_stability((100, 100)) is False


### PR DESCRIPTION
## Summary
- add `core.location_selector` with helpers for hotspot travel
- add `core.waypoint_verifier` for stability checks
- update trainer travel to use new waypoint verifier
- expose helpers from `core.__init__`
- unit tests for new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860928cf0e48331bce4b97ba02749dd