### PR TITLE
Implement travel helpers and update TravelManager

### DIFF
--- a/core/travel_manager.py
+++ b/core/travel_manager.py
@@ -44,7 +44,7 @@ class TravelManager:
             self.trainers = {}
 
     # --------------------------------------------------
-    def go_to_trainer(self, profession: str) -> None:
+    def go_to_trainer(self, profession: str, *, agent=None) -> None:
         """Navigate to the trainer location for ``profession``.
 
         This method performs waypoint travel and location verification only.
@@ -62,8 +62,12 @@ class TravelManager:
         planet = trainer.get("planet")
         city = trainer.get("city")
 
-        go_to_waypoint(coords, planet=planet, city=city)
-        verify_location(coords, planet=planet, city=city)
+        if agent is None:
+            go_to_waypoint(coords, planet=planet, city=city)
+            verify_location(coords, planet=planet, city=city)
+        else:
+            go_to_waypoint(coords, planet=planet, city=city, agent=agent)
+            verify_location(coords, planet=planet, city=city, agent=agent)
 
     # --------------------------------------------------
     def train_profession(self, profession: str) -> List[str]:

--- a/utils/travel.py
+++ b/utils/travel.py
@@ -1,0 +1,39 @@
+"""Basic movement helpers for navigating to waypoints."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Tuple, Any, Optional
+
+from modules.travel.location_selector import select_target
+from src.movement.movement_profiles import walk_to_coords
+from utils.waypoint_verifier import verify_waypoint as _verify_waypoint
+
+Coords = Sequence[int]
+
+
+def go_to_waypoint(
+    coords: Iterable[int], *, planet: str | None = None, city: str | None = None, agent: Any = None
+) -> Optional[dict]:
+    """Travel to ``coords`` optionally navigating to ``planet`` and ``city`` first."""
+
+    if planet and city:
+        select_target(planet, city, agent=agent)
+    xy = tuple(coords)
+    if len(xy) != 2:
+        raise ValueError("coords must contain two values")
+    x, y = xy
+    walk_to_coords(agent, int(x), int(y))
+    return {"x": int(x), "y": int(y)}
+
+
+def verify_location(
+    coords: Iterable[int], *, planet: str | None = None, city: str | None = None, agent: Any = None
+) -> bool:
+    """Verify that the player remains near ``coords``."""
+
+    # ``planet`` and ``city`` parameters are currently unused but included for
+    # API compatibility with :class:`core.TravelManager`.
+    xy = tuple(coords)
+    if len(xy) != 2:
+        raise ValueError("coords must contain two values")
+    return _verify_waypoint((int(xy[0]), int(xy[1])))


### PR DESCRIPTION
## Summary
- add `utils.travel` with `go_to_waypoint` and `verify_location`
- allow passing a movement agent to `TravelManager.go_to_trainer`
- delegate travel and verification through the new helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6860bc0c66dc8331ba000ceed328abbf