### PR TITLE
Add BuildManager utility

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,6 +2,7 @@
 
 from .location_selector import locate_hotspot, travel_to_target
 from .profession_leveler import ProfessionLeveler
+from .build_manager import BuildManager
 from .trainer_ocr import (
     extract_text_from_trainer_region,
     get_untrained_skills_from_text,
@@ -21,6 +22,7 @@ __all__ = [
     "TrainerScanner",
     "TravelManager",
     "ProfessionLeveler",
+    "BuildManager",
     "travel_to_target",
     "locate_hotspot",
     "verify_waypoint_stability",

--- a/core/build_manager.py
+++ b/core/build_manager.py
@@ -1,0 +1,64 @@
+"""Utilities for loading and tracking profession builds."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from modules.professions import progress_tracker
+
+
+BUILD_DIR = Path(__file__).resolve().parents[1] / "profiles" / "builds"
+
+
+class BuildManager:
+    """Load build files and determine skill progression."""
+
+    def __init__(self, build_name: str | None = None) -> None:
+        self.profession: str = ""
+        self.skills: List[str] = []
+        self.xp_costs: Dict[str, int] = {}
+        if build_name is not None:
+            self.load_build(build_name)
+
+    # --------------------------------------------------------------
+    def load_build(self, name: str) -> None:
+        """Load build ``name`` from :data:`BUILD_DIR`."""
+
+        path = BUILD_DIR / f"{name}.json"
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+
+        self.profession = str(data.get("profession", ""))
+        self.skills = list(data.get("skills", []))
+
+        try:
+            prof_data = progress_tracker.load_profession(self.profession.lower())
+            xp_map = prof_data.get("xp_costs", {})
+        except Exception:
+            xp_map = {}
+
+        self.xp_costs = {skill: int(xp_map.get(skill, 0)) for skill in self.skills}
+
+    # --------------------------------------------------------------
+    def get_next_skill(self, known_skills: Iterable[str]) -> Optional[str]:
+        """Return the next skill in the build not present in ``known_skills``."""
+
+        for skill in self.skills:
+            if skill not in known_skills:
+                return skill
+        return None
+
+    # --------------------------------------------------------------
+    def is_skill_completed(self, skill: str, known_skills: Iterable[str]) -> bool:
+        """Return ``True`` if ``skill`` is contained in ``known_skills``."""
+
+        return skill in known_skills
+
+    # --------------------------------------------------------------
+    def get_required_xp(self, skill: str) -> int:
+        """Return the XP required for ``skill`` according to the build."""
+
+        return int(self.xp_costs.get(skill, 0))
+

--- a/tests/test_build_manager.py
+++ b/tests/test_build_manager.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.build_manager import BuildManager
+from modules.professions import progress_tracker
+
+
+def setup_build(tmp_path):
+    build_dir = tmp_path / "builds"
+    build_dir.mkdir()
+    build_data = {
+        "profession": "Medic",
+        "skills": ["Novice Medic", "Intermediate Medicine"]
+    }
+    (build_dir / "basic.json").write_text(json.dumps(build_data))
+    return build_dir, build_data
+
+
+def mock_profession_data():
+    return {
+        "xp_costs": {
+            "Novice Medic": 0,
+            "Intermediate Medicine": 1000
+        }
+    }
+
+
+def test_load_build(monkeypatch, tmp_path):
+    build_dir, data = setup_build(tmp_path)
+    monkeypatch.setattr("core.build_manager.BUILD_DIR", build_dir)
+    monkeypatch.setattr(progress_tracker, "load_profession", lambda p: mock_profession_data())
+
+    bm = BuildManager()
+    bm.load_build("basic")
+
+    assert bm.profession == "Medic"
+    assert bm.skills == data["skills"]
+    assert bm.get_required_xp("Intermediate Medicine") == 1000
+
+
+def test_build_progression(monkeypatch, tmp_path):
+    build_dir, _ = setup_build(tmp_path)
+    monkeypatch.setattr("core.build_manager.BUILD_DIR", build_dir)
+    monkeypatch.setattr(progress_tracker, "load_profession", lambda p: mock_profession_data())
+
+    bm = BuildManager("basic")
+
+    assert bm.get_next_skill([]) == "Novice Medic"
+    assert bm.get_next_skill(["Novice Medic"]) == "Intermediate Medicine"
+    assert bm.get_next_skill(["Novice Medic", "Intermediate Medicine"]) is None
+
+    assert bm.is_skill_completed("Novice Medic", ["Novice Medic"]) is True
+    assert bm.is_skill_completed("Intermediate Medicine", ["Novice Medic"]) is False


### PR DESCRIPTION
## Summary
- implement `core.build_manager` for loading build profiles
- expose `BuildManager` from `core`
- test build loading and progression logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860d0f4da788331bc8e85b1c1e14725