### PR TITLE
Use BuildManager for trainer progression

### DIFF
--- a/tests/test_trainer_seeker.py
+++ b/tests/test_trainer_seeker.py
@@ -6,27 +6,39 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from modules.training import trainer_seeker
 
 
+class DummyBuild:
+    def __init__(self, skill=None, xp=0):
+        self.skill = skill
+        self.xp = xp
+
+    def get_next_skill(self, skills):
+        return self.skill
+
+    def get_required_xp(self, skill):
+        return self.xp
+
+
 def test_seek_training_no_skill(monkeypatch):
-    monkeypatch.setattr(trainer_seeker.progress_tracker, "recommend_next_skill", lambda p, s: None)
+    bm = DummyBuild()
     called = {}
     monkeypatch.setattr(trainer_seeker.trainer_navigator, "log_event", lambda msg: called.setdefault("log", msg))
-    result = trainer_seeker.seek_training("medic", [])
+    result = trainer_seeker.seek_training("medic", [], build_manager=bm)
     assert result is False
     assert "No further skills" in called["log"]
 
 
 def test_seek_training_insufficient_xp(monkeypatch):
-    monkeypatch.setattr(trainer_seeker.progress_tracker, "recommend_next_skill", lambda p, s: {"skill": "Intermediate", "xp": 1000})
+    bm = DummyBuild("Intermediate", 1000)
     monkeypatch.setattr(trainer_seeker, "read_xp_via_ocr", lambda: 500)
     called = {}
     monkeypatch.setattr(trainer_seeker.trainer_navigator, "log_event", lambda msg: called.setdefault("log", msg))
-    result = trainer_seeker.seek_training("medic", [])
+    result = trainer_seeker.seek_training("medic", [], build_manager=bm)
     assert result is False
     assert "need 1000 XP" in called["log"]
 
 
 def test_seek_training_success(monkeypatch):
-    monkeypatch.setattr(trainer_seeker.progress_tracker, "recommend_next_skill", lambda p, s: {"skill": "Intermediate", "xp": 500})
+    bm = DummyBuild("Intermediate", 500)
     monkeypatch.setattr(trainer_seeker, "read_xp_via_ocr", lambda: 1000)
     calls = {}
     monkeypatch.setattr(trainer_seeker, "visit_trainer", lambda a, profession, planet="tatooine", city="mos_eisley": calls.setdefault("visit", (profession, planet, city)))
@@ -34,7 +46,7 @@ def test_seek_training_success(monkeypatch):
     monkeypatch.setattr(trainer_seeker.trainer_navigator, "log_training_event", lambda *a, **k: calls.setdefault("train", True))
     monkeypatch.setattr(trainer_seeker, "_run_training_macro", lambda skill: calls.setdefault("macro", skill))
 
-    result = trainer_seeker.seek_training("medic", ["Novice Artisan"], agent="A", planet="corellia", city="coronet")
+    result = trainer_seeker.seek_training("medic", ["Novice Artisan"], agent="A", planet="corellia", city="coronet", build_manager=bm)
 
     assert result is True
     assert calls["visit"] == ("medic", "corellia", "coronet")


### PR DESCRIPTION
## Summary
- hook BuildManager into `trainer_seeker`
- adapt trainer logic to check skill progress via BuildManager
- update unit tests for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860d25566d8833199c7156e9074f586