### PR TITLE
Add Flask dashboard with build and status pages

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from flask import Flask, render_template
+
+# Directory containing build definitions
+BUILD_DIR = Path(__file__).resolve().parents[1] / "profiles" / "builds"
+
+# Potential locations for session logs
+LOG_DIRS = [Path("logs"), Path("data") / "session_logs"]
+
+app = Flask(__name__)
+
+
+def _latest_session_log() -> Optional[Path]:
+    """Return the most recently modified session log file if one exists."""
+    candidates = []
+    for directory in LOG_DIRS:
+        if directory.exists():
+            candidates.extend(directory.glob("session_*.json"))
+            # include plain JSON names from session_logger
+            candidates.extend(directory.glob("*.json"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/builds")
+def list_builds():
+    builds = []
+    if BUILD_DIR.exists():
+        builds = [p.stem for p in BUILD_DIR.glob("*.json")]
+    return render_template("builds.html", builds=sorted(builds))
+
+
+@app.route("/status")
+def status():
+    log_path = _latest_session_log()
+    data = None
+    if log_path and log_path.exists():
+        try:
+            with open(log_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            data = None
+    return render_template("status.html", log=data)
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=8000)

--- a/dashboard/templates/builds.html
+++ b/dashboard/templates/builds.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Builds</title>
+</head>
+<body>
+    <h1>Available Builds</h1>
+    <ul>
+    {% for build in builds %}
+        <li>{{ build }}</li>
+    {% else %}
+        <li>No builds found.</li>
+    {% endfor %}
+    </ul>
+    <p><a href="/">Back</a></p>
+</body>
+</html>

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Dashboard</title>
+</head>
+<body>
+    <h1>Project MorningStar Dashboard</h1>
+    <ul>
+        <li><a href="/builds">Available Builds</a></li>
+        <li><a href="/status">Session Status</a></li>
+    </ul>
+</body>
+</html>

--- a/dashboard/templates/status.html
+++ b/dashboard/templates/status.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Session Status</title>
+</head>
+<body>
+    <h1>Active Session Status</h1>
+    {% if log %}
+        <pre>{{ log|tojson(indent=2) }}</pre>
+    {% else %}
+        <p>No session data found.</p>
+    {% endif %}
+    <p><a href="/">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a small Flask app in `dashboard/app.py`
- add Jinja templates for homepage, builds list and session status
- expose routes `/builds` and `/status` and default to running on port `8000`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860d3a88eb48331a1a59e0a26f483fb