### PR TITLE
Add Flask dashboard tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@
 
 requests>=2.0   # used by profession_importer tests
 discord.py      # used by Discord relay tests
+Flask           # used by dashboard tests

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dashboard.app import app
+
+
+def test_builds_route(monkeypatch, tmp_path):
+    build_dir = tmp_path / "builds"
+    build_dir.mkdir()
+    (build_dir / "foo.json").write_text("{}")
+    monkeypatch.setattr("dashboard.app.BUILD_DIR", build_dir)
+
+    with app.test_client() as client:
+        resp = client.get("/builds")
+        assert resp.status_code == 200
+        assert b"foo" in resp.data
+
+
+def test_status_route(monkeypatch, tmp_path):
+    log_file = tmp_path / "session_test.json"
+    log_file.write_text(json.dumps({"hello": "world"}))
+    monkeypatch.setattr("dashboard.app.LOG_DIRS", [tmp_path])
+
+    with app.test_client() as client:
+        resp = client.get("/status")
+        assert resp.status_code == 200
+        assert b"hello" in resp.data


### PR DESCRIPTION
## Summary
- test Flask dashboard `/builds` and `/status` routes
- ensure BuildManager tests cover loading and next skill logic
- include Flask as a test dependency

## Testing
- `pytest -q tests/test_dashboard.py tests/test_build_manager.py`

------
https://chatgpt.com/codex/tasks/task_b_6860d4f9ca4883319758b340afc9ba61