### PR TITLE
Add quest monitor module

### DIFF
--- a/modules/quest_monitor.py
+++ b/modules/quest_monitor.py
@@ -1,0 +1,75 @@
+"""Quest engagement monitoring and waypoint tracking."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Iterable, Tuple
+
+from utils.db import get_db_connection
+from utils.logging_utils import log_event
+
+Coords = Tuple[int, int]
+
+
+class QuestMonitor:
+    """Monitor quest engagement times and mission waypoints."""
+
+    def __init__(self, *, timeout: float = 300.0, db=None) -> None:
+        self.timeout = float(timeout)
+        self.db = db or get_db_connection()
+        self.last_engagement = time.time()
+
+    # --------------------------------------------------
+    def record_engagement(self, now: float | None = None) -> None:
+        """Record the most recent engagement time."""
+        self.last_engagement = now if now is not None else time.time()
+
+    # --------------------------------------------------
+    def check_relocation(self, now: float | None = None) -> bool:
+        """Return ``True`` if a relocation scan was triggered."""
+        now = now if now is not None else time.time()
+        if now - self.last_engagement >= self.timeout:
+            self.sweep_area()
+            self.last_engagement = now
+            return True
+        return False
+
+    # --------------------------------------------------
+    def sweep_area(self) -> None:  # pragma: no cover - placeholder
+        """Scan nearby lairs/NPCs for updated mission waypoints."""
+        log_event("[QuestMonitor] Sweeping area for mission waypoints")
+        # Placeholder for real scanning logic
+
+    # --------------------------------------------------
+    def update_waypoint(self, coords: Iterable[int]) -> None:
+        """Persist ``coords`` to the mission database."""
+        xy = tuple(int(c) for c in coords)
+        if len(xy) != 2:
+            raise ValueError("coords must contain two values")
+        try:
+            self.db.missions.update_one(
+                {"x": xy[0], "y": xy[1]},
+                {"$set": {"x": xy[0], "y": xy[1]}},
+                upsert=True,
+            )
+            log_event(f"[QuestMonitor] Updated mission waypoint: {xy}")
+        except Exception:
+            log_event("[QuestMonitor] Failed to update mission DB")
+
+    # --------------------------------------------------
+    def manual_override(
+        self,
+        is_held: Callable[[], bool],
+        get_position: Callable[[], Coords],
+        now: float | None = None,
+    ) -> bool:
+        """Log the current position when the override key is held."""
+        if not is_held():
+            return False
+        coords = get_position()
+        self.update_waypoint(coords)
+        self.record_engagement(now)
+        return True
+
+
+__all__ = ["QuestMonitor"]

--- a/tests/test_quest_monitor.py
+++ b/tests/test_quest_monitor.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.quest_monitor import QuestMonitor
+
+
+class DummyCollection:
+    def __init__(self) -> None:
+        self.updates = []
+
+    def update_one(self, query, update, upsert=False):
+        self.updates.append((query, update, upsert))
+
+
+class DummyDB:
+    def __init__(self) -> None:
+        self.missions = DummyCollection()
+
+
+def test_relocation_trigger(monkeypatch):
+    db = DummyDB()
+    monitor = QuestMonitor(timeout=10, db=db)
+    t = [0]
+    monkeypatch.setattr(time, "time", lambda: t[0])
+    monitor.record_engagement()
+
+    t[0] = 5
+    assert monitor.check_relocation() is False
+
+    t[0] = 15
+    called = []
+    monkeypatch.setattr(monitor, "sweep_area", lambda: called.append(True))
+    assert monitor.check_relocation() is True
+    assert called == [True]
+    assert monitor.last_engagement == 15
+
+
+def test_manual_override_resets(monkeypatch):
+    db = DummyDB()
+    monitor = QuestMonitor(timeout=10, db=db)
+    t = [0]
+    monkeypatch.setattr(time, "time", lambda: t[0])
+    monitor.record_engagement()
+
+    t[0] = 12
+    monkeypatch.setattr(monitor, "update_waypoint", lambda c: db.missions.update_one({}, {"$set": {"coords": c}}, True))
+    monitor.manual_override(lambda: True, lambda: (100, 200))
+    assert db.missions.updates[-1][1]["$set"]["coords"] == (100, 200)
+    assert monitor.last_engagement == 12
+
+    t[0] = 20
+    assert monitor.check_relocation() is False


### PR DESCRIPTION
## Summary
- add `QuestMonitor` for relocation monitoring and waypoint updates
- allow manual override for assisted learning
- test relocation triggers and timer resets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6860e0905324833196dac64a3fac8d9a