### PR TITLE
Add license hooks decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,15 @@ make test
 ```
 Note: When running tests in headless CI, `pyautogui` requires a virtual display such as Xvfb.
 
+
 Launch the test suite with `xvfb-run -a pytest` or an equivalent wrapper.
+
+## License Hooks
+
+Several entry points are decorated with ``@requires_license`` from
+``utils.license_hooks``. When the ``ANDROID_MS11_LICENSE`` environment variable
+is absent the decorator issues a warning and continues execution. Future
+releases will replace this placeholder with real license validation.
 
 ## Wiki Content and Licensing
 

--- a/android_ms11/modes/bounty_farming_mode.py
+++ b/android_ms11/modes/bounty_farming_mode.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from typing import Mapping, Any
 
 from core import farm_profile_loader
+from utils.license_hooks import requires_license
 
 from core.location_selector import travel_to_target, locate_hotspot
 from core.waypoint_verifier import verify_waypoint_stability
 
 
+@requires_license
 def run(profile: Mapping[str, Any] | str | None = None, session=None) -> None:
     """Travel to the configured target and verify the mission waypoint.
 

--- a/android_ms11/modes/combat_assist_mode.py
+++ b/android_ms11/modes/combat_assist_mode.py
@@ -1,6 +1,7 @@
 """Combat assist mode implementation."""
 
 from core.session_manager import SessionManager
+from utils.license_hooks import requires_license
 
 
 def start_afk_combat(character_name: str) -> None:
@@ -12,6 +13,7 @@ def start_afk_combat(character_name: str) -> None:
     print("⚔️ Simulation: Defeated 5 mobs at waypoint.")
 
 
+@requires_license
 def run(config: dict, session: SessionManager) -> None:
     """Run combat assist loop using ``session`` for tracking."""
 

--- a/android_ms11/modes/crafting_mode.py
+++ b/android_ms11/modes/crafting_mode.py
@@ -1,3 +1,6 @@
+from utils.license_hooks import requires_license
+
+
 def start_crafting(character_name: str) -> None:
     """Simulate a short crafting session for the given character."""
 
@@ -7,6 +10,7 @@ def start_crafting(character_name: str) -> None:
     print("🔧 Simulation: Crafted 2 Mineral Survey Devices.")
 
 
+@requires_license
 def run(config, session=None):
     """Main entry point for this mode."""
 

--- a/android_ms11/modes/dancer_mode.py
+++ b/android_ms11/modes/dancer_mode.py
@@ -1,3 +1,7 @@
+from utils.license_hooks import requires_license
+
+
+@requires_license
 def run(config, session=None):
     """Main entry point for this mode."""
     pass

--- a/android_ms11/modes/entertainer_mode.py
+++ b/android_ms11/modes/entertainer_mode.py
@@ -1,6 +1,9 @@
 """Entertainer mode stub."""
 
+from utils.license_hooks import requires_license
 
+
+@requires_license
 def run(session=None):
     """Placeholder for entertainer behavior."""
     print("🎭 Performing entertainment routines...")

--- a/android_ms11/modes/medic_mode.py
+++ b/android_ms11/modes/medic_mode.py
@@ -1,3 +1,6 @@
+from utils.license_hooks import requires_license
+
+
 def start_medic(character_name: str) -> None:
     """Simulate healing and buffing nearby allies."""
 
@@ -7,6 +10,7 @@ def start_medic(character_name: str) -> None:
     print("🧪 Simulation: Buffed 3 nearby players.")
 
 
+@requires_license
 def run(config, session=None):
     """Main entry point for this mode."""
 

--- a/android_ms11/modes/profession_mode.py
+++ b/android_ms11/modes/profession_mode.py
@@ -1,3 +1,7 @@
+from utils.license_hooks import requires_license
+
+
+@requires_license
 def run(config, session=None):
     """Main entry point for this mode."""
     pass

--- a/android_ms11/modes/quest_mode.py
+++ b/android_ms11/modes/quest_mode.py
@@ -3,8 +3,10 @@
 from core.session_manager import SessionManager
 from src.quest_selector import select_quest
 from src.quest_executor import execute_quest
+from utils.license_hooks import requires_license
 
 
+@requires_license
 def run(config: dict, session: SessionManager) -> None:
     """Run quest mode using ``session`` to track actions."""
 

--- a/android_ms11/modes/rls_mode.py
+++ b/android_ms11/modes/rls_mode.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from android_ms11.core import loot_session, ocr_loot_scanner, rls_logic
+from utils.license_hooks import requires_license
 
 
+@requires_license
 def run(
     config: dict | None = None,
     session=None,

--- a/android_ms11/modes/support_mode.py
+++ b/android_ms11/modes/support_mode.py
@@ -6,8 +6,10 @@ from android_ms11.core import (
     assist_manager,
     party_manager,
 )
+from utils.license_hooks import requires_license
 
 
+@requires_license
 def run(session=None, max_loops: int | None = None) -> None:
     """Entry point for support mode.
 

--- a/android_ms11/modes/whisper_mode.py
+++ b/android_ms11/modes/whisper_mode.py
@@ -1,3 +1,6 @@
+from utils.license_hooks import requires_license
+
+
 def start_buff_by_tell(character_name: str) -> None:
     """Simulate responding to buff requests sent via tell."""
 
@@ -7,6 +10,7 @@ def start_buff_by_tell(character_name: str) -> None:
     print("📨 Simulation: Responded to 2 buff requests.")
 
 
+@requires_license
 def run(config, session=None):
     """Main entry point for this mode."""
 

--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -5,8 +5,10 @@ from datetime import datetime
 
 from core.xp_estimator import XPEstimator
 from utils.session_utils import track_xp_gain
+from utils.license_hooks import requires_license
 
 class SessionManager:
+    @requires_license
     def __init__(self, mode: str = "unknown"):
         self.session_id = str(uuid.uuid4())[:8]
         self.mode = mode

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ from core.repeat_utils import run_repeating_mode
 from utils.logging_utils import log_event
 from utils.load_trainers import load_trainers
 from utils.check_buff_status import update_buff_state
+from utils.license_hooks import requires_license
 from modules.skills.training_check import get_trainable_skills
 from modules.travel.trainer_travel import travel_to_trainer
 from src.movement.agent_mover import MovementAgent
@@ -196,6 +197,7 @@ def run_mode(
         return {}
 
 
+@requires_license
 def main(argv: list[str] | None = None) -> None:
     """Run a demo session using the selected runtime profile."""
 

--- a/src/modes/grinding.py
+++ b/src/modes/grinding.py
@@ -1,6 +1,8 @@
 from src.automation.automator import run_state_monitor_loop
+from utils.license_hooks import requires_license
 
 
+@requires_license
 def start() -> None:
     """Entry point for grinding mode."""
     print("[MODE] Grinding mode started")

--- a/src/modes/medic.py
+++ b/src/modes/medic.py
@@ -1,6 +1,8 @@
 from src.automation.automator import run_state_monitor_loop
+from utils.license_hooks import requires_license
 
 
+@requires_license
 def start() -> None:
     """Entry point for medic mode."""
     print("[MODE] Medic mode started")

--- a/src/modes/mode_runner.py
+++ b/src/modes/mode_runner.py
@@ -1,6 +1,8 @@
 from src.modes import questing, medic, grinding
+from utils.license_hooks import requires_license
 
 
+@requires_license
 def run_mode(mode_name: str) -> None:
     """Dispatch to the requested automation mode."""
     if mode_name == "questing":

--- a/src/modes/questing.py
+++ b/src/modes/questing.py
@@ -1,5 +1,6 @@
 import json
 from quest_engine import handle_quest_step
+from utils.license_hooks import requires_license
 
 
 def load_legacy_quest():
@@ -36,6 +37,7 @@ def run_questing_mode(character: str) -> None:
         print("[\u2713] All Legacy steps complete.")
 
 
+@requires_license
 def start() -> None:
     """Entry point for questing mode."""
     run_questing_mode("Player")

--- a/tests/test_license_hooks.py
+++ b/tests/test_license_hooks.py
@@ -1,0 +1,20 @@
+import os
+import warnings
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.license_hooks import requires_license
+
+
+def test_requires_license_warns(monkeypatch):
+    monkeypatch.delenv("ANDROID_MS11_LICENSE", raising=False)
+
+    @requires_license
+    def sample_fn():
+        return 1
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        assert sample_fn() == 1
+        assert any("License check is not implemented" in str(w.message) for w in rec)

--- a/utils/license_hooks.py
+++ b/utils/license_hooks.py
@@ -1,0 +1,30 @@
+"""Decorators for optional license checks."""
+
+from __future__ import annotations
+
+from functools import wraps
+import os
+import warnings
+
+
+def requires_license(func):
+    """Warn if the application is run without a license key.
+
+    The decorator checks for ``ANDROID_MS11_LICENSE`` in the environment and
+    emits a :class:`RuntimeWarning` when it is missing. This placeholder will be
+    replaced by a real license validation routine in the future.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if os.environ.get("ANDROID_MS11_LICENSE") is None:
+            warnings.warn(
+                "License check is not implemented yet. Running in trial mode.",
+                RuntimeWarning,
+            )
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+__all__ = ["requires_license"]


### PR DESCRIPTION
## Summary
- add `requires_license` decorator in `utils`
- document license hooks in README
- apply decorator to core entry points and mode runners
- test warning when license missing

## Testing
- `pip install flask`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686146b00a688331ae02f9ec7cac794f