### PR TITLE
Introduce ProfileValidationError for profile loader

### DIFF
--- a/core/profile_loader.py
+++ b/core/profile_loader.py
@@ -4,6 +4,59 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
+
+class ProfileValidationError(Exception):
+    """Raised when a profile file fails validation."""
+
+
+def validate_profile(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate ``data`` and attach build information.
+
+    Returns the validated profile dict.
+    """
+
+    for field, expected_type in REQUIRED_FIELDS.items():
+        if field not in data:
+            raise ProfileValidationError(f"Missing required field: {field}")
+        if not isinstance(data[field], expected_type):
+            raise ProfileValidationError(
+                f"{field} must be of type {expected_type.__name__}"
+            )
+
+    for field, expected_type in OPTIONAL_FIELDS.items():
+        if field in data:
+            if not isinstance(data[field], expected_type):
+                raise ProfileValidationError(
+                    f"{field} must be of type {expected_type.__name__}"
+                )
+            if field == "farming_target":
+                required_keys = {"planet", "city", "hotspot"}
+                missing = required_keys - data[field].keys()
+                if missing:
+                    raise ProfileValidationError(
+                        f"farming_target missing keys: {', '.join(sorted(missing))}"
+                    )
+                if not all(isinstance(data[field][k], str) for k in required_keys):
+                    raise ProfileValidationError("farming_target values must be strings")
+
+    data.setdefault("auto_train", False)
+
+    build_name = data.get("skill_build")
+    build_path = BUILD_DIR / f"{build_name}.json"
+    if not build_path.exists():
+        raise ProfileValidationError(f"Build file not found: {build_name}")
+    try:
+        with open(build_path, "r", encoding="utf-8") as fh:
+            build_data = json.load(fh)
+    except Exception as exc:
+        raise ProfileValidationError(f"Invalid build file: {build_name}") from exc
+    if not isinstance(build_data, dict):
+        raise ProfileValidationError("Invalid build file structure")
+
+    data["build"] = build_data
+
+    return data
+
 PROFILE_DIR = Path(__file__).resolve().parents[1] / "profiles"
 BUILD_DIR = PROFILE_DIR / "builds"
 
@@ -35,42 +88,4 @@ def load_profile(name: str) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
 
-    for field, expected_type in REQUIRED_FIELDS.items():
-        if field not in data:
-            raise ValueError(f"Missing required field: {field}")
-        if not isinstance(data[field], expected_type):
-            raise ValueError(f"{field} must be of type {expected_type.__name__}")
-
-    for field, expected_type in OPTIONAL_FIELDS.items():
-        if field in data:
-            if not isinstance(data[field], expected_type):
-                raise ValueError(
-                    f"{field} must be of type {expected_type.__name__}"
-                )
-            if field == "farming_target":
-                required_keys = {"planet", "city", "hotspot"}
-                missing = required_keys - data[field].keys()
-                if missing:
-                    raise ValueError(
-                        f"farming_target missing keys: {', '.join(sorted(missing))}"
-                    )
-                if not all(isinstance(data[field][k], str) for k in required_keys):
-                    raise ValueError("farming_target values must be strings")
-
-    data.setdefault("auto_train", False)
-
-    build_name = data.get("skill_build")
-    build_path = BUILD_DIR / f"{build_name}.json"
-    if not build_path.exists():
-        raise ValueError(f"Build file not found: {build_name}")
-    try:
-        with open(build_path, "r", encoding="utf-8") as fh:
-            build_data = json.load(fh)
-    except Exception as exc:
-        raise ValueError(f"Invalid build file: {build_name}") from exc
-    if not isinstance(build_data, dict):
-        raise ValueError("Invalid build file structure")
-
-    data["build"] = build_data
-
-    return data
+    return validate_profile(data)

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.profile_loader import load_profile
+from core.profile_loader import load_profile, ProfileValidationError
 
 
 def test_load_profile_valid(tmp_path, monkeypatch):
@@ -81,7 +81,7 @@ def test_invalid_farming_target(tmp_path, monkeypatch):
     (build_dir / "basic.json").write_text(json.dumps({"skills": []}))
     monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
     monkeypatch.setattr("core.profile_loader.BUILD_DIR", build_dir)
-    with pytest.raises(ValueError):
+    with pytest.raises(ProfileValidationError):
         load_profile("demo")
 
 
@@ -111,7 +111,7 @@ def test_missing_build_file(tmp_path, monkeypatch):
     build_dir.mkdir()
     monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
     monkeypatch.setattr("core.profile_loader.BUILD_DIR", build_dir)
-    with pytest.raises(ValueError):
+    with pytest.raises(ProfileValidationError):
         load_profile("demo")
 
 
@@ -136,5 +136,5 @@ def test_invalid_build_structure(tmp_path, monkeypatch):
     (build_dir / "bad.json").write_text("[]")
     monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
     monkeypatch.setattr("core.profile_loader.BUILD_DIR", build_dir)
-    with pytest.raises(ValueError):
+    with pytest.raises(ProfileValidationError):
         load_profile("demo")


### PR DESCRIPTION
## Summary
- add custom `ProfileValidationError` class
- move validation logic into `validate_profile()`
- call `validate_profile()` from `load_profile`
- update unit tests for new exception

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614c74958483319a58edf258f71426