### PR TITLE
Support txt build files in profile loader

### DIFF
--- a/core/profile_loader.py
+++ b/core/profile_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
@@ -42,9 +43,17 @@ def validate_profile(data: Dict[str, Any]) -> Dict[str, Any]:
     data.setdefault("auto_train", False)
 
     build_name = data.get("skill_build")
-    build_path = BUILD_DIR / f"{build_name}.json"
-    if not build_path.exists():
+    json_path = BUILD_DIR / f"{build_name}.json"
+    txt_path = BUILD_DIR / f"{build_name}.txt"
+    if json_path.exists():
+        build_path = json_path
+    elif txt_path.exists():
+        build_path = txt_path
+    else:
         raise ProfileValidationError(f"Build file not found: {build_name}")
+
+    logging.info("Using build file %s", build_path)
+
     try:
         with open(build_path, "r", encoding="utf-8") as fh:
             build_data = json.load(fh)

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -36,6 +36,31 @@ def test_load_profile_valid(tmp_path, monkeypatch):
     assert prof["build"] == {"skills": []}
 
 
+def test_load_profile_txt_build(tmp_path, monkeypatch):
+    data = {
+        "support_target": "Leader",
+        "preferred_trainers": {"medic": "trainer"},
+        "default_mode": "medic",
+        "skip_modes": ["crafting"],
+        "farming_targets": ["Bandit"],
+        "farming_target": {
+            "planet": "Naboo",
+            "city": "Theed",
+            "hotspot": "Cantina",
+        },
+        "skill_build": "basic",
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(data))
+    build_dir = tmp_path / "builds"
+    build_dir.mkdir()
+    (build_dir / "basic.txt").write_text(json.dumps({"skills": ["A"]}))
+    monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
+    monkeypatch.setattr("core.profile_loader.BUILD_DIR", build_dir)
+    prof = load_profile("demo")
+    assert prof["build"] == {"skills": ["A"]}
+
+
 def test_auto_train_default(tmp_path, monkeypatch):
     data = {
         "support_target": "Leader",


### PR DESCRIPTION
## Summary
- allow profile loader to resolve `.json` or `.txt` build files
- log which build file is selected
- test `.txt` build resolution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614dd01b508331b116f8cf0827aabd