### PR TITLE
Implement build completion helpers

### DIFF
--- a/core/build_manager.py
+++ b/core/build_manager.py
@@ -41,9 +41,8 @@ class BuildManager:
 
         self.xp_costs = {skill: int(xp_map.get(skill, 0)) for skill in self.skills}
 
-    # --------------------------------------------------------------
-    def get_next_skill(self, known_skills: Iterable[str]) -> Optional[str]:
-        """Return the next skill in the build not present in ``known_skills``."""
+    def _next_missing_skill(self, known_skills: Iterable[str]) -> Optional[str]:
+        """Return the next skill in :attr:`skills` not in ``known_skills``."""
 
         for skill in self.skills:
             if skill not in known_skills:
@@ -51,10 +50,28 @@ class BuildManager:
         return None
 
     # --------------------------------------------------------------
+    def get_next_skill(self, known_skills: Iterable[str]) -> Optional[str]:
+        """Return the next skill in the build not present in ``known_skills``."""
+
+        return self._next_missing_skill(known_skills)
+
+    # --------------------------------------------------------------
+    def get_next_trainable_skill(self, current_skills: Iterable[str]) -> Optional[str]:
+        """Return the next skill that has not yet been learned."""
+
+        return self._next_missing_skill(current_skills)
+
+    # --------------------------------------------------------------
     def is_skill_completed(self, skill: str, known_skills: Iterable[str]) -> bool:
         """Return ``True`` if ``skill`` is contained in ``known_skills``."""
 
         return skill in known_skills
+
+    # --------------------------------------------------------------
+    def is_build_complete(self, current_skills: Iterable[str]) -> bool:
+        """Return ``True`` if all skills for the build have been learned."""
+
+        return self.get_next_trainable_skill(current_skills) is None
 
     # --------------------------------------------------------------
     def get_required_xp(self, skill: str) -> int:

--- a/tests/test_build_manager.py
+++ b/tests/test_build_manager.py
@@ -54,3 +54,18 @@ def test_build_progression(monkeypatch, tmp_path):
 
     assert bm.is_skill_completed("Novice Medic", ["Novice Medic"]) is True
     assert bm.is_skill_completed("Intermediate Medicine", ["Novice Medic"]) is False
+
+
+def test_next_trainable_and_completion(monkeypatch, tmp_path):
+    build_dir, _ = setup_build(tmp_path)
+    monkeypatch.setattr("core.build_manager.BUILD_DIR", build_dir)
+    monkeypatch.setattr(progress_tracker, "load_profession", lambda p: mock_profession_data())
+
+    bm = BuildManager("basic")
+
+    # get_next_trainable_skill should mirror get_next_skill
+    assert bm.get_next_trainable_skill([]) == bm.get_next_skill([])
+    assert bm.get_next_trainable_skill(["Novice Medic"]) == bm.get_next_skill(["Novice Medic"])
+
+    assert not bm.is_build_complete(["Novice Medic"])
+    assert bm.is_build_complete(["Novice Medic", "Intermediate Medicine"])


### PR DESCRIPTION
## Summary
- add internal utility for finding missing skills
- add `get_next_trainable_skill` and `is_build_complete`
- alias existing `get_next_skill` to use new logic
- unit tests for new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68615102c3208331be1a18b2572b6792