### PR TITLE
Remove unused static routes file

### DIFF
--- a/dashboard/templates/static/routes.py
+++ b/dashboard/templates/static/routes.py
@@ -1,1 +1,0 @@
-# Static route definitions for the dashboard application


### PR DESCRIPTION
## Summary
- remove the placeholder `routes.py` file under dashboard templates

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68615b2277e083318da7a0e6708e3f6d