### PR TITLE
Skip dashboard tests when Flask is unavailable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ make test
 
 The `test` target installs the dependencies and then runs `pytest` for you.
 
+Some test modules rely on optional dependencies. The dashboard tests, for
+example, require the `flask` package which is listed in
+`requirements-test.txt`. These tests will automatically be skipped if the
+package is not installed.
+
 For quick checks during development you can run just the mode specific tests
 once the requirements are installed:
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,9 @@
 import os
 import sys
 import json
+import pytest
+
+pytest.importorskip("flask")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
## Summary
- skip dashboard tests if Flask isn't installed
- explain that Flask is an optional test dependency in CONTRIBUTING

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68616642ae748331a42051d8477b34fb