### PR TITLE
Support TXT build files

### DIFF
--- a/core/build_manager.py
+++ b/core/build_manager.py
@@ -26,7 +26,15 @@ class BuildManager:
     def load_build(self, name: str) -> None:
         """Load build ``name`` from :data:`BUILD_DIR`."""
 
-        path = BUILD_DIR / f"{name}.json"
+        json_path = BUILD_DIR / f"{name}.json"
+        txt_path = BUILD_DIR / f"{name}.txt"
+        if json_path.exists():
+            path = json_path
+        elif txt_path.exists():
+            path = txt_path
+        else:
+            raise FileNotFoundError(f"Build file not found: {name}")
+
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -37,8 +37,9 @@ def index():
 def list_builds():
     builds = []
     if BUILD_DIR.exists():
-        builds = [p.stem for p in BUILD_DIR.glob("*.json")]
-    return render_template("builds.html", builds=sorted(builds))
+        builds.extend(p.stem for p in BUILD_DIR.glob("*.json"))
+        builds.extend(p.stem for p in BUILD_DIR.glob("*.txt"))
+    return render_template("builds.html", builds=sorted(set(builds)))
 
 
 @app.route("/status")

--- a/tests/test_build_manager.py
+++ b/tests/test_build_manager.py
@@ -19,6 +19,17 @@ def setup_build(tmp_path):
     return build_dir, build_data
 
 
+def setup_txt_build(tmp_path):
+    build_dir = tmp_path / "builds"
+    build_dir.mkdir()
+    build_data = {
+        "profession": "Medic",
+        "skills": ["Novice Medic", "Intermediate Medicine"],
+    }
+    (build_dir / "basic.txt").write_text(json.dumps(build_data))
+    return build_dir, build_data
+
+
 def mock_profession_data():
     return {
         "xp_costs": {
@@ -30,6 +41,19 @@ def mock_profession_data():
 
 def test_load_build(monkeypatch, tmp_path):
     build_dir, data = setup_build(tmp_path)
+    monkeypatch.setattr("core.build_manager.BUILD_DIR", build_dir)
+    monkeypatch.setattr(progress_tracker, "load_profession", lambda p: mock_profession_data())
+
+    bm = BuildManager()
+    bm.load_build("basic")
+
+    assert bm.profession == "Medic"
+    assert bm.skills == data["skills"]
+    assert bm.get_required_xp("Intermediate Medicine") == 1000
+
+
+def test_load_txt_build(monkeypatch, tmp_path):
+    build_dir, data = setup_txt_build(tmp_path)
     monkeypatch.setattr("core.build_manager.BUILD_DIR", build_dir)
     monkeypatch.setattr(progress_tracker, "load_profession", lambda p: mock_profession_data())
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -14,12 +14,14 @@ def test_builds_route(monkeypatch, tmp_path):
     build_dir = tmp_path / "builds"
     build_dir.mkdir()
     (build_dir / "foo.json").write_text("{}")
+    (build_dir / "bar.txt").write_text("{}")
     monkeypatch.setattr("dashboard.app.BUILD_DIR", build_dir)
 
     with app.test_client() as client:
         resp = client.get("/builds")
         assert resp.status_code == 200
         assert b"foo" in resp.data
+        assert b"bar" in resp.data
 
 
 def test_status_route(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- expand `BuildManager.load_build` to search for `.json` and `.txt` build files
- list TXT build files in the dashboard
- add TXT build load test coverage

## Testing
- `pytest -q tests/test_build_manager.py tests/test_dashboard.py tests/test_profile_loader.py::test_load_profile_txt_build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68616f7478d4833199e44227c387074b