### PR TITLE
Improve build loading by supporting multiple extensions

### DIFF
--- a/core/build_manager.py
+++ b/core/build_manager.py
@@ -26,17 +26,16 @@ class BuildManager:
     def load_build(self, name: str) -> None:
         """Load build ``name`` from :data:`BUILD_DIR`."""
 
-        json_path = BUILD_DIR / f"{name}.json"
-        txt_path = BUILD_DIR / f"{name}.txt"
-        if json_path.exists():
-            path = json_path
-        elif txt_path.exists():
-            path = txt_path
-        else:
+        extensions = [".json", ".txt"]
+        data = None
+        for ext in extensions:
+            path = BUILD_DIR / f"{name}{ext}"
+            if path.exists():
+                with open(path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                break
+        if data is None:
             raise FileNotFoundError(f"Build file not found: {name}")
-
-        with open(path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
 
         self.profession = str(data.get("profession", ""))
         self.skills = list(data.get("skills", []))


### PR DESCRIPTION
## Summary
- allow `BuildManager.load_build` to look for both `.json` and `.txt` files
- raise `FileNotFoundError` with build name when no matching file exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686176987d2483319c9f539d6822e9db