### PR TITLE
Add rifleman build and BuildManager test

### DIFF
--- a/profiles/builds/rifleman.txt
+++ b/profiles/builds/rifleman.txt
@@ -1,0 +1,5 @@
+{
+  "profession": "Rifleman",
+  "skills": ["Novice Marksman", "Master Rifleman"]
+}
+

--- a/tests/test_build_manager.py
+++ b/tests/test_build_manager.py
@@ -113,3 +113,22 @@ def test_load_repo_txt_build(monkeypatch, tmp_path):
         assert bm.skills == ["Novice Medic"]
     finally:
         backup.rename(src_json)
+
+def test_load_repo_rifleman_build(monkeypatch):
+    monkeypatch.setattr(
+        progress_tracker,
+        "load_profession",
+        lambda p: {
+            "xp_costs": {
+                "Novice Marksman": 0,
+                "Master Rifleman": 8000,
+            }
+        },
+    )
+
+    bm = BuildManager("rifleman")
+
+    assert bm.profession == "Rifleman"
+    assert bm.skills == ["Novice Marksman", "Master Rifleman"]
+    assert bm.get_required_xp("Master Rifleman") == 8000
+


### PR DESCRIPTION
## Summary
- add `rifleman.txt` build in `profiles/builds`
- test BuildManager can load repo txt build and parse XP

## Testing
- `pytest tests/test_build_manager.py::test_load_repo_rifleman_build -q`
- `pytest -k build_manager -q`


------
https://chatgpt.com/codex/tasks/task_b_68617dab1f84833187693d40737083e1