### PR TITLE
Add progress tracker utilities

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -12,6 +12,7 @@ from .trainer_ocr import (
 from .trainer_scanner import TrainerScanner, scan_trainer_skills
 from .travel_manager import TravelManager
 from .waypoint_verifier import verify_waypoint_stability
+from .progress_tracker import load_session, save_session, record_skill
 
 __all__ = [
     "preprocess_image",
@@ -26,4 +27,7 @@ __all__ = [
     "travel_to_target",
     "locate_hotspot",
     "verify_waypoint_stability",
+    "load_session",
+    "save_session",
+    "record_skill",
 ]

--- a/core/progress_tracker.py
+++ b/core/progress_tracker.py
@@ -1,0 +1,48 @@
+"""Helpers for persisting profession progress across sessions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+_DEFAULT_DATA = {"completed_skills": []}
+
+
+def load_session(path: Path) -> Dict[str, Any]:
+    """Return saved progress from ``path`` or an empty structure."""
+    if not path.exists():
+        return {"completed_skills": []}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            raise ValueError("Invalid progress file")
+    except Exception:
+        return {"completed_skills": []}
+    data.setdefault("completed_skills", [])
+    if not isinstance(data["completed_skills"], list):
+        data["completed_skills"] = list(data.get("completed_skills", []))
+    return data
+
+
+def save_session(path: Path, data: Dict[str, Any]) -> None:
+    """Write ``data`` to ``path`` atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    tmp.replace(path)
+
+
+def record_skill(path: Path, skill: str) -> None:
+    """Append ``skill`` to the completed list and save."""
+    data = load_session(path)
+    skills = data.setdefault("completed_skills", [])
+    if skill not in skills:
+        skills.append(skill)
+        save_session(path, data)
+
+
+__all__ = ["load_session", "save_session", "record_skill"]

--- a/tests/test_core_progress_tracker.py
+++ b/tests/test_core_progress_tracker.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core import progress_tracker
+
+
+def test_load_empty_session(tmp_path):
+    path = tmp_path / "progress.json"
+    data = progress_tracker.load_session(path)
+    assert data == {"completed_skills": []}
+
+
+def test_resume_progress(tmp_path):
+    path = tmp_path / "progress.json"
+    progress_tracker.save_session(path, {"completed_skills": ["Skill1"]})
+    loaded = progress_tracker.load_session(path)
+    assert loaded["completed_skills"] == ["Skill1"]
+
+
+def test_record_skill_saves(tmp_path):
+    path = tmp_path / "progress.json"
+    progress_tracker.record_skill(path, "SkillA")
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["completed_skills"] == ["SkillA"]
+
+
+def test_resume_after_restart(tmp_path):
+    path = tmp_path / "progress.json"
+    progress_tracker.record_skill(path, "SkillA")
+    progress_tracker.record_skill(path, "SkillB")
+    loaded = progress_tracker.load_session(path)
+    assert loaded["completed_skills"] == ["SkillA", "SkillB"]


### PR DESCRIPTION
## Summary
- add `core.progress_tracker` for persisting skill progress
- re-export helpers from `core.__init__`
- test progress tracker load/save behavior

## Testing
- `pytest -k progress_tracker -q`

------
https://chatgpt.com/codex/tasks/task_b_6861865168148331b6908ed668fb7c62