### PR TITLE
Add get_completed_skills to BuildManager and tests

### DIFF
--- a/core/build_manager.py
+++ b/core/build_manager.py
@@ -86,3 +86,9 @@ class BuildManager:
 
         return int(self.xp_costs.get(skill, 0))
 
+    # --------------------------------------------------------------
+    def get_completed_skills(self, known_skills: Iterable[str]) -> list[str]:
+        """Return a list of build skills that are present in ``known_skills``."""
+
+        return [s for s in self.skills if s in known_skills]
+

--- a/tests/test_build_manager.py
+++ b/tests/test_build_manager.py
@@ -79,6 +79,7 @@ def test_build_progression(monkeypatch, tmp_path):
 
     assert bm.is_skill_completed("Novice Medic", ["Novice Medic"]) is True
     assert bm.is_skill_completed("Intermediate Medicine", ["Novice Medic"]) is False
+    assert bm.get_completed_skills(["Novice Medic"]) == ["Novice Medic"]
 
 
 def test_next_trainable_and_completion(monkeypatch, tmp_path):
@@ -94,6 +95,12 @@ def test_next_trainable_and_completion(monkeypatch, tmp_path):
 
     assert not bm.is_build_complete(["Novice Medic"])
     assert bm.is_build_complete(["Novice Medic", "Intermediate Medicine"])
+
+    assert bm.get_completed_skills(["Novice Medic"]) == ["Novice Medic"]
+    assert bm.get_completed_skills(["Novice Medic", "Intermediate Medicine"]) == [
+        "Novice Medic",
+        "Intermediate Medicine",
+    ]
 
 
 def test_load_repo_txt_build(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- implement `get_completed_skills` in `core.build_manager.BuildManager`
- verify completed skills via new assertions in build manager tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686188992a408331a0407964a89663b0