### PR TITLE
Pass planet and city to TravelManager

### DIFF
--- a/core/travel_manager.py
+++ b/core/travel_manager.py
@@ -44,7 +44,14 @@ class TravelManager:
             self.trainers = {}
 
     # --------------------------------------------------
-    def go_to_trainer(self, profession: str, *, agent=None) -> bool:
+    def go_to_trainer(
+        self,
+        profession: str,
+        *,
+        agent=None,
+        planet: str | None = None,
+        city: str | None = None,
+    ) -> bool:
         """Navigate to the trainer location for ``profession``.
 
         This method performs waypoint travel and location verification only.
@@ -66,18 +73,16 @@ class TravelManager:
                 or entry.get("coords")
                 or [entry.get("x", 0), entry.get("y", 0)]
             )
-            planet = entry.get("planet")
-            city = entry.get("city")
+            p = planet or entry.get("planet")
+            c = city or entry.get("city")
 
             try:
                 if agent is None:
-                    go_to_waypoint(coords, planet=planet, city=city)
-                    success = verify_location(coords, planet=planet, city=city)
+                    go_to_waypoint(coords, planet=p, city=c)
+                    success = verify_location(coords, planet=p, city=c)
                 else:
-                    go_to_waypoint(coords, planet=planet, city=city, agent=agent)
-                    success = verify_location(
-                        coords, planet=planet, city=city, agent=agent
-                    )
+                    go_to_waypoint(coords, planet=p, city=c, agent=agent)
+                    success = verify_location(coords, planet=p, city=c, agent=agent)
             except Exception:
                 success = False
 

--- a/modules/training/trainer_seeker.py
+++ b/modules/training/trainer_seeker.py
@@ -99,7 +99,12 @@ def seek_training(
     )
     tm = travel_manager or TravelManager()
     try:
-        success = tm.go_to_trainer(profession, agent=agent)
+        success = tm.go_to_trainer(
+            profession,
+            agent=agent,
+            planet=planet,
+            city=city,
+        )
     except Exception:
         trainer_navigator.log_event("Player busy; will retry later")
         return False

--- a/tests/test_trainer_seeker.py
+++ b/tests/test_trainer_seeker.py
@@ -43,7 +43,7 @@ def test_seek_training_success(monkeypatch):
     monkeypatch.setattr(trainer_seeker, "read_xp_via_ocr", lambda: 1000)
     calls = {}
     tm = MagicMock()
-    tm.go_to_trainer = lambda prof, agent=None: calls.setdefault("go", (prof, agent)) or True
+    tm.go_to_trainer = lambda prof, agent=None, planet=None, city=None: calls.setdefault("go", (prof, agent, planet, city)) or True
     monkeypatch.setattr(trainer_seeker.trainer_navigator, "log_event", lambda msg: calls.setdefault("log", []).append(msg))
     monkeypatch.setattr(trainer_seeker.trainer_navigator, "log_training_event", lambda *a, **k: calls.setdefault("train", True))
     monkeypatch.setattr(trainer_seeker, "_run_training_macro", lambda skill: calls.setdefault("macro", skill))
@@ -51,7 +51,7 @@ def test_seek_training_success(monkeypatch):
     result = trainer_seeker.seek_training("medic", ["Novice Artisan"], agent="A", planet="corellia", city="coronet", build_manager=bm, travel_manager=tm)
 
     assert result is True
-    assert calls["go"] == ("medic", "A")
+    assert calls["go"] == ("medic", "A", "corellia", "coronet")
     assert calls["macro"] == "Intermediate"
     assert calls.get("train") is True
 
@@ -60,7 +60,7 @@ def test_seek_training_busy_defers(monkeypatch):
     bm = DummyBuild("Intermediate", 500)
     monkeypatch.setattr(trainer_seeker, "read_xp_via_ocr", lambda: 1000)
     tm = MagicMock()
-    def raise_busy(prof, agent=None):
+    def raise_busy(prof, agent=None, planet=None, city=None):
         raise Exception("busy")
     tm.go_to_trainer = raise_busy
     called = []
@@ -76,7 +76,7 @@ def test_seek_training_all_fail(monkeypatch, tmp_path):
     bm = DummyBuild("Intermediate", 500)
     monkeypatch.setattr(trainer_seeker, "read_xp_via_ocr", lambda: 1000)
     tm = MagicMock()
-    tm.go_to_trainer = lambda prof, agent=None: False
+    tm.go_to_trainer = lambda prof, agent=None, planet=None, city=None: False
     calls = {}
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(trainer_seeker.trainer_navigator, "log_event", lambda msg: calls.setdefault("log", msg))


### PR DESCRIPTION
## Summary
- forward planet and city arguments from `trainer_seeker.seek_training`
- allow `TravelManager.go_to_trainer` to accept optional planet and city overrides
- update trainer seeker tests for the new call signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68618e70e9188331b925f5752d42a149