### PR TITLE
Update dashboard progress view

### DIFF
--- a/dashboard/templates/status.html
+++ b/dashboard/templates/status.html
@@ -8,13 +8,19 @@
     <h1>Active Session Status</h1>
     {% if build %}
         <p>Current Build: {{ build }}</p>
-        <p>Build Progress: {{ progress.completed_skills | length if progress else 0 }}/{{ progress.total_skills if progress else 0 }}</p>
+    {% endif %}
+    {% if progress %}
+        <p>Completed Skills: {{ progress.completed_skills|join(', ') }}</p>
+        <p>Next Skill: {{ progress.next_skill or 'None' }}</p>
+        <p>Progress: {{ progress.percent }}%</p>
+        <p>Build Progress: {{ progress.completed_skills | length }}/{{ progress.total_skills }}</p>
     {% endif %}
     {% if log %}
         <pre>{{ log|tojson(indent=2) }}</pre>
     {% else %}
         <p>No session data found.</p>
     {% endif %}
+    <button onclick="window.location.reload()">Refresh</button>
     <p><a href="/">Back</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- leverage core progress tracker for dashboard
- surface progress stats and refresh button in status template
- test for new progress output

## Testing
- `pytest -q tests/test_dashboard.py` *(fails: ModuleNotFoundError: No module named 'flask' leading to skipped tests)*

------
https://chatgpt.com/codex/tasks/task_b_68619145e33c8331be07c707db3f3609