### PR TITLE
Add session tracker module

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -13,6 +13,11 @@ from .trainer_scanner import TrainerScanner, scan_trainer_skills
 from .travel_manager import TravelManager
 from .waypoint_verifier import verify_waypoint_stability
 from .progress_tracker import load_session, save_session, record_skill
+from .session_tracker import (
+    load_session as load_session_state,
+    save_session as save_session_state,
+    update_session_key,
+)
 
 __all__ = [
     "preprocess_image",
@@ -30,4 +35,7 @@ __all__ = [
     "load_session",
     "save_session",
     "record_skill",
+    "load_session_state",
+    "save_session_state",
+    "update_session_key",
 ]

--- a/core/session_tracker.py
+++ b/core/session_tracker.py
@@ -1,0 +1,39 @@
+"""Simple session persistence utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+SESSION_FILE = "session_state.json"
+DEFAULT_SESSION: Dict[str, Any] = {}
+
+
+def load_session() -> Dict[str, Any]:
+    """Return data from :data:`SESSION_FILE` or defaults."""
+    if os.path.exists(SESSION_FILE):
+        try:
+            with open(SESSION_FILE, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            pass
+    return DEFAULT_SESSION.copy()
+
+
+def save_session(session_data: Dict[str, Any]) -> None:
+    """Write ``session_data`` to :data:`SESSION_FILE`."""
+    with open(SESSION_FILE, "w", encoding="utf-8") as fh:
+        json.dump(session_data, fh, indent=2)
+
+
+def update_session_key(key: str, value: Any) -> None:
+    """Update ``key`` in the saved session."""
+    data = load_session()
+    data[key] = value
+    save_session(data)
+
+
+__all__ = ["load_session", "save_session", "update_session_key"]


### PR DESCRIPTION
## Summary
- implement `core.session_tracker` for persisting session data
- re-export new utilities from `core.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861988f1f74833198b0ae1623c8fdc1