### PR TITLE
Fix default planet/city handling for trainer travel

### DIFF
--- a/modules/training/trainer_seeker.py
+++ b/modules/training/trainer_seeker.py
@@ -97,13 +97,15 @@ def seek_training(
     trainer_navigator.log_event(
         f"Travelling to {profession} trainer to learn {next_skill}"
     )
+    target_planet = planet or DEFAULT_PLANET
+    target_city = city or DEFAULT_CITY
     tm = travel_manager or TravelManager()
     try:
         success = tm.go_to_trainer(
             profession,
             agent=agent,
-            planet=planet,
-            city=city,
+            planet=target_planet,
+            city=target_city,
         )
     except Exception:
         trainer_navigator.log_event("Player busy; will retry later")


### PR DESCRIPTION
## Summary
- ensure `seek_training` always sets a fallback `planet` and `city`
- pass these values when calling `TravelManager.go_to_trainer`

## Testing
- `pytest -k trainer_seeker -q`
- `pytest tests/test_trainer_seeker.py::test_seek_training_success -q`

------
https://chatgpt.com/codex/tasks/task_b_6861a1615c4083318bb3aecc5f1818ed