### PR TITLE
Add TerminalFarmer

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,5 @@
+"""Convenience imports for common modules."""
+
+from .farming.terminal_farm import TerminalFarmer
+
+__all__ = ["TerminalFarmer"]

--- a/modules/farming/__init__.py
+++ b/modules/farming/__init__.py
@@ -1,0 +1,5 @@
+"""Farming utilities."""
+
+from .terminal_farm import TerminalFarmer
+
+__all__ = ["TerminalFarmer"]

--- a/modules/farming/terminal_farm.py
+++ b/modules/farming/terminal_farm.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from src.vision.ocr import screen_text
+
+Mission = Dict[str, int | str | Tuple[int, int]]
+
+_MISSION_RE = re.compile(
+    r"(?P<name>[\w '\-]+)\s+(?P<x>-?\d+)\s*[,:]?\s*(?P<y>-?\d+)\s+(?P<distance>\d+)m",
+    re.IGNORECASE,
+)
+
+
+class TerminalFarmer:
+    """Parse and accept bounty missions from a terminal."""
+
+    def __init__(self, profile_path: str = "config/farming_profile.json") -> None:
+        path = Path(profile_path)
+        self.profile: Dict[str, object] = {}
+        if path.exists():
+            with path.open("r", encoding="utf-8") as fh:
+                self.profile = json.load(fh)
+
+    # --------------------------------------------------
+    def parse_missions(self, text: str) -> List[Mission]:
+        """Return list of mission details parsed from ``text``."""
+        missions: List[Mission] = []
+        for line in text.splitlines():
+            match = _MISSION_RE.search(line)
+            if not match:
+                continue
+            mission: Mission = {
+                "name": match.group("name").strip(),
+                "coords": (int(match.group("x")), int(match.group("y"))),
+                "distance": int(match.group("distance")),
+            }
+            missions.append(mission)
+        return missions
+
+    # --------------------------------------------------
+    def execute_run(self, *, board_text: str | None = None) -> List[Mission]:
+        """Parse and filter missions from the terminal screen."""
+        if board_text is None:
+            board_text = screen_text()
+        missions = self.parse_missions(board_text)
+        max_distance = int(self.profile.get("max_distance", 9999))
+        accepted = [m for m in missions if m["distance"] <= max_distance]
+        for mission in accepted:
+            coords = mission["coords"]
+            print(
+                f"[TerminalFarmer] Mission {mission['name']} at {coords} {mission['distance']}m"
+            )
+        return accepted
+
+
+__all__ = ["TerminalFarmer"]


### PR DESCRIPTION
## Summary
- implement `TerminalFarmer` under `modules.farming`
- expose the new class via `modules` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861b138252483318dc8a3f0412ae68e