### PR TITLE
Add farming result logger

### DIFF
--- a/core/session_tracker.py
+++ b/core/session_tracker.py
@@ -36,4 +36,28 @@ def update_session_key(key: str, value: Any) -> None:
     save_session(data)
 
 
-__all__ = ["load_session", "save_session", "update_session_key"]
+def log_farming_result(mobs: list[str], earned_credits: int) -> None:
+    """Update farming statistics in :data:`SESSION_FILE`.
+
+    Parameters
+    ----------
+    mobs:
+        Sequence of mob names defeated during a mission.
+    earned_credits:
+        Credits earned from the mission.
+    """
+
+    data = load_session()
+    data["missions_completed"] = int(data.get("missions_completed", 0)) + 1
+    data["total_credits_earned"] = (
+        int(data.get("total_credits_earned", 0)) + int(earned_credits)
+    )
+
+    mob_counts = data.setdefault("mob_counts", {})
+    for mob in mobs:
+        mob_counts[mob] = int(mob_counts.get(mob, 0)) + 1
+
+    save_session(data)
+
+
+__all__ = ["load_session", "save_session", "update_session_key", "log_farming_result"]

--- a/tests/test_core_session_tracker.py
+++ b/tests/test_core_session_tracker.py
@@ -21,3 +21,19 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     assert (tmp_path / session_tracker.SESSION_FILE).exists()
     loaded = session_tracker.load_session()
     assert loaded == payload
+
+
+def test_log_farming_result(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    session_tracker.log_farming_result(["bandit", "bandit", "thug"], 100)
+    data = session_tracker.load_session()
+    assert data["missions_completed"] == 1
+    assert data["total_credits_earned"] == 100
+    assert data["mob_counts"] == {"bandit": 2, "thug": 1}
+
+    session_tracker.log_farming_result(["bandit"], 50)
+    data = session_tracker.load_session()
+    assert data["missions_completed"] == 2
+    assert data["total_credits_earned"] == 150
+    assert data["mob_counts"] == {"bandit": 3, "thug": 1}


### PR DESCRIPTION
## Summary
- expand `core.session_tracker` with a `log_farming_result` helper
- export the new helper and test its behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861b313f5648331bbfb2f5125854585