### PR TITLE
Add TerminalFarmer tests

### DIFF
--- a/modules/farming/terminal_farm.py
+++ b/modules/farming/terminal_farm.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from src.vision.ocr import screen_text
+from core.session_tracker import log_farming_result
 
 Mission = Dict[str, int | str | Tuple[int, int]]
 
@@ -53,6 +54,11 @@ class TerminalFarmer:
             coords = mission["coords"]
             print(
                 f"[TerminalFarmer] Mission {mission['name']} at {coords} {mission['distance']}m"
+            )
+        if accepted:
+            log_farming_result(
+                [m["name"] for m in accepted],
+                len(accepted),
             )
         return accepted
 

--- a/tests/farming/test_terminal_farm.py
+++ b/tests/farming/test_terminal_farm.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from modules.farming.terminal_farm import TerminalFarmer
+import core.session_tracker as session_tracker
+
+
+def test_parse_missions_filters_invalid_lines():
+    farmer = TerminalFarmer()
+    text = """
+    Bandit Camp 100,200 300m
+    Not a mission
+    Rebel Hideout -50,-75 500m
+    """
+    missions = farmer.parse_missions(text)
+    assert missions == [
+        {"name": "Bandit Camp", "coords": (100, 200), "distance": 300},
+        {"name": "Rebel Hideout", "coords": (-50, -75), "distance": 500},
+    ]
+
+
+def test_execute_run_logs_result(monkeypatch):
+    farmer = TerminalFarmer()
+    farmer.profile["max_distance"] = 60
+    board_text = """
+    Close Target 10,10 50m
+    Far Target 20,20 100m
+    """
+    calls = []
+    def fake_log(mobs, credits):
+        calls.append((mobs, credits))
+    monkeypatch.setattr("modules.farming.terminal_farm.log_farming_result", fake_log)
+    accepted = farmer.execute_run(board_text=board_text)
+    assert accepted == [
+        {"name": "Close Target", "coords": (10, 10), "distance": 50}
+    ]
+    assert calls == [(["Close Target"], 1)]
+


### PR DESCRIPTION
## Summary
- test terminal farming parsing and execution
- log farming results from TerminalFarmer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6861bb4fca508331baaea4890dbb13d0