### PR TITLE
Update terminal farmer logging

### DIFF
--- a/modules/farming/terminal_farm.py
+++ b/modules/farming/terminal_farm.py
@@ -11,7 +11,8 @@ from core.session_tracker import log_farming_result
 Mission = Dict[str, int | str | Tuple[int, int]]
 
 _MISSION_RE = re.compile(
-    r"(?P<name>[\w '\-]+)\s+(?P<x>-?\d+)\s*[,:]?\s*(?P<y>-?\d+)\s+(?P<distance>\d+)m",
+    r"(?P<name>[\w '\-]+)\s+(?P<x>-?\d+)\s*[,:]?\s*(?P<y>-?\d+)\s+"
+    r"(?P<distance>\d+)m(?:\s+(?P<credits>\d+)c)?",
     re.IGNORECASE,
 )
 
@@ -39,6 +40,8 @@ class TerminalFarmer:
                 "coords": (int(match.group("x")), int(match.group("y"))),
                 "distance": int(match.group("distance")),
             }
+            if match.group("credits"):
+                mission["credits"] = int(match.group("credits"))
             missions.append(mission)
         return missions
 
@@ -56,9 +59,10 @@ class TerminalFarmer:
                 f"[TerminalFarmer] Mission {mission['name']} at {coords} {mission['distance']}m"
             )
         if accepted:
+            earned = sum(int(m.get("credits", 0)) for m in accepted)
             log_farming_result(
                 [m["name"] for m in accepted],
-                len(accepted),
+                earned,
             )
         return accepted
 

--- a/tests/farming/test_terminal_farm.py
+++ b/tests/farming/test_terminal_farm.py
@@ -25,8 +25,8 @@ def test_execute_run_logs_result(monkeypatch):
     farmer = TerminalFarmer()
     farmer.profile["max_distance"] = 60
     board_text = """
-    Close Target 10,10 50m
-    Far Target 20,20 100m
+    Close Target 10,10 50m 500c
+    Far Target 20,20 100m 2000c
     """
     calls = []
     def fake_log(mobs, credits):
@@ -34,7 +34,7 @@ def test_execute_run_logs_result(monkeypatch):
     monkeypatch.setattr("modules.farming.terminal_farm.log_farming_result", fake_log)
     accepted = farmer.execute_run(board_text=board_text)
     assert accepted == [
-        {"name": "Close Target", "coords": (10, 10), "distance": 50}
+        {"name": "Close Target", "coords": (10, 10), "distance": 50, "credits": 500}
     ]
-    assert calls == [(["Close Target"], 1)]
+    assert calls == [(["Close Target"], 500)]
 


### PR DESCRIPTION
## Summary
- capture credit amounts from mission board
- log earned credits in TerminalFarmer
- expect updated values in farming tests

## Testing
- `pytest -q tests/farming/test_terminal_farm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861d0cbad188331a6d5b157002e764d