### PR TITLE
Switch TerminalFarmer to logger

### DIFF
--- a/modules/farming/terminal_farm.py
+++ b/modules/farming/terminal_farm.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 
 from src.vision.ocr import screen_text
 from core.session_tracker import log_farming_result
+from utils.logger import logger
 
 Mission = Dict[str, int | str | Tuple[int, int]]
 
@@ -55,8 +56,11 @@ class TerminalFarmer:
         accepted = [m for m in missions if m["distance"] <= max_distance]
         for mission in accepted:
             coords = mission["coords"]
-            print(
-                f"[TerminalFarmer] Mission {mission['name']} at {coords} {mission['distance']}m"
+            logger.info(
+                "[TerminalFarmer] Mission %s at %s %dm",
+                mission["name"],
+                coords,
+                mission["distance"],
             )
         if accepted:
             earned = sum(int(m.get("credits", 0)) for m in accepted)

--- a/tests/farming/test_terminal_farm.py
+++ b/tests/farming/test_terminal_farm.py
@@ -7,6 +7,7 @@ from modules.farming.terminal_farm import TerminalFarmer
 import core.session_tracker as session_tracker
 
 
+
 def test_parse_missions_filters_invalid_lines():
     farmer = TerminalFarmer()
     text = """
@@ -32,9 +33,21 @@ def test_execute_run_logs_result(monkeypatch):
     def fake_log(mobs, credits):
         calls.append((mobs, credits))
     monkeypatch.setattr("modules.farming.terminal_farm.log_farming_result", fake_log)
+
+    logs = []
+    class DummyLogger:
+        def info(self, msg, *args):
+            logs.append(msg % args)
+
+    monkeypatch.setattr(
+        "modules.farming.terminal_farm.logger",
+        DummyLogger(),
+    )
+
     accepted = farmer.execute_run(board_text=board_text)
     assert accepted == [
         {"name": "Close Target", "coords": (10, 10), "distance": 50, "credits": 500}
     ]
     assert calls == [(["Close Target"], 500)]
+    assert logs == ["[TerminalFarmer] Mission Close Target at (10, 10) 50m"]
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,13 @@
+import logging
+import os
+
+DEFAULT_LOG_PATH = os.path.join("logs", "app.log")
+
+logger = logging.getLogger("ms11")
+if not logger.handlers:
+    os.makedirs(os.path.dirname(DEFAULT_LOG_PATH), exist_ok=True)
+    handler = logging.FileHandler(DEFAULT_LOG_PATH, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary
- add project logger utility
- log mission acceptance in `TerminalFarmer`
- update tests to intercept logger messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861d4b1eb8083319dccdc2e4bb49b27