### PR TITLE
Add TerminalFarmer to bounty mode

### DIFF
--- a/android_ms11/modes/bounty_farming_mode.py
+++ b/android_ms11/modes/bounty_farming_mode.py
@@ -10,6 +10,7 @@ from utils.license_hooks import requires_license
 
 from core.location_selector import travel_to_target, locate_hotspot
 from core.waypoint_verifier import verify_waypoint_stability
+from modules import TerminalFarmer
 
 
 @requires_license
@@ -51,6 +52,8 @@ def run(profile: Mapping[str, Any] | str | None = None, session=None) -> None:
     )
 
     print("[Bounty] Accepting missions...")
+    farmer = TerminalFarmer()
+    farmer.execute_run()
     print("[Bounty] Missions accepted.")
 
     if coords:


### PR DESCRIPTION
## Summary
- instantiate and execute `TerminalFarmer` during bounty mode runs
- test that bounty mode invokes `TerminalFarmer`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861e01d3b84833188886f90d828316e