### PR TITLE
Replace max_distance with distance_limit

### DIFF
--- a/config/farming_profile.json
+++ b/config/farming_profile.json
@@ -2,6 +2,6 @@
   "preferred_terminal": "mission_terminal",
   "preferred_direction": "north",
   "mob_priority": [],
-  "max_distance": 1000,
+  "distance_limit": 1000,
   "blacklist_mobs": []
 }

--- a/core/farm_profile_loader.py
+++ b/core/farm_profile_loader.py
@@ -11,7 +11,7 @@ REQUIRED_FIELDS = {
     "city": str,
     "quest_type": str,
     "preferred_directions": list,
-    "max_distance": int,
+    "distance_limit": int,
 }
 
 

--- a/docs/modes/farming_mode.md
+++ b/docs/modes/farming_mode.md
@@ -9,7 +9,7 @@ The default profile lives at `config/farming_profile.json` and supports the keys
 - `preferred_terminal` – name of the terminal to use for missions.
 - `preferred_direction` – cardinal direction your character should face before scanning.
 - `mob_priority` – ordered list of mob names to prioritize when multiple matches are found.
-- `max_distance` – only accept missions within this distance in meters.
+- `distance_limit` – only accept missions within this distance in meters.
 - `blacklist_mobs` – list of mobs to always ignore.
 
 ## Expected Output
@@ -42,7 +42,7 @@ Bandit Camp 100,200 300m 500c
 Rebel Hideout -50,-75 500m
 """
 farmer = TerminalFarmer()
-farmer.profile["max_distance"] = 400
+farmer.profile["distance_limit"] = 400
 accepted = farmer.execute_run(board_text=sample)
 ```
 

--- a/modules/farming/terminal_farm.py
+++ b/modules/farming/terminal_farm.py
@@ -52,8 +52,8 @@ class TerminalFarmer:
         if board_text is None:
             board_text = screen_text()
         missions = self.parse_missions(board_text)
-        max_distance = int(self.profile.get("max_distance", 9999))
-        accepted = [m for m in missions if m["distance"] <= max_distance]
+        distance_limit = int(self.profile.get("distance_limit", 9999))
+        accepted = [m for m in missions if m["distance"] <= distance_limit]
         for mission in accepted:
             coords = mission["coords"]
             logger.info(

--- a/profiles/farms/tox_spin_farm.json
+++ b/profiles/farms/tox_spin_farm.json
@@ -3,5 +3,5 @@
   "city": "mining",
   "quest_type": "toxic_spin",
   "preferred_directions": ["north", "west"],
-  "max_distance": 800
+  "distance_limit": 800
 }

--- a/tests/farming/test_terminal_farm.py
+++ b/tests/farming/test_terminal_farm.py
@@ -24,7 +24,7 @@ def test_parse_missions_filters_invalid_lines():
 
 def test_execute_run_logs_result(monkeypatch):
     farmer = TerminalFarmer()
-    farmer.profile["max_distance"] = 60
+    farmer.profile["distance_limit"] = 60
     board_text = """
     Close Target 10,10 50m 500c
     Far Target 20,20 100m 2000c

--- a/tests/test_bounty_farming_mode.py
+++ b/tests/test_bounty_farming_mode.py
@@ -14,7 +14,7 @@ def test_run_travels_and_verifies(monkeypatch, tmp_path):
         "city": "mos_eisley",
         "quest_type": "bounty",
         "preferred_directions": [],
-        "max_distance": 100,
+        "distance_limit": 100,
     }
     farm_dir = tmp_path / "farms"
     farm_dir.mkdir()

--- a/tests/test_farm_profile_loader.py
+++ b/tests/test_farm_profile_loader.py
@@ -14,7 +14,7 @@ def test_load_farm_profile_valid(tmp_path, monkeypatch):
         "city": "mos_eisley",
         "quest_type": "bounty",
         "preferred_directions": ["north"],
-        "max_distance": 500,
+        "distance_limit": 500,
     }
     farm_dir = tmp_path / "farms"
     farm_dir.mkdir()
@@ -31,7 +31,7 @@ def test_load_farm_profile_missing_field(tmp_path, monkeypatch):
         "city": "mos_eisley",
         "quest_type": "bounty",
         "preferred_directions": ["north"],
-        # max_distance missing
+        # distance_limit missing
     }
     farm_dir = tmp_path / "farms"
     farm_dir.mkdir()


### PR DESCRIPTION
## Summary
- use `distance_limit` instead of `max_distance` in farming config
- adjust TerminalFarmer and farm profile loader
- update docs and sample profiles
- update tests to the new key

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861e50a31188331998981ca8d8d78a6