### PR TITLE
Switch to logger in core modules and scripts

### DIFF
--- a/core/profession_leveler.py
+++ b/core/profession_leveler.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import List
 
 from .travel_manager import TravelManager
+from utils.logger import logger
 try:  # pragma: no cover - optional dependency
     from modules.professions import progress_tracker
 except Exception:  # pragma: no cover
@@ -42,7 +43,7 @@ class ProfessionLeveler:
     def level_all_professions(self) -> None:
         for profession in self.profession_plan:
             if profession not in self.travel_manager.trainers:
-                print(f"[Leveler] No trainer entry for {profession}")
+                logger.info("[Leveler] No trainer entry for %s", profession)
                 continue
             self.level_profession(profession)
 
@@ -54,16 +55,19 @@ class ProfessionLeveler:
         self.travel_manager.train_profession(profession_name)
         skills = self.travel_manager.trainer_scanner.scan()
         if skills:
-            print(f"[Leveler] {profession_name} trainer offers: {skills}")
+            logger.info("[Leveler] %s trainer offers: %s", profession_name, skills)
         else:
-            print(f"[Leveler] No skills detected for {profession_name}")
+            logger.info("[Leveler] No skills detected for %s", profession_name)
 
         if progress_tracker and skills:
             try:
                 rec = progress_tracker.recommend_next_skill(profession_name, skills)
                 if rec:
-                    print(
-                        f"[Leveler] Next skill for {profession_name}: {rec['skill']} ({rec.get('xp', 0)} XP)"
+                    logger.info(
+                        "[Leveler] Next skill for %s: %s (%s XP)",
+                        profession_name,
+                        rec["skill"],
+                        rec.get("xp", 0),
                     )
             except Exception:
                 pass

--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from core.xp_estimator import XPEstimator
 from utils.session_utils import track_xp_gain
 from utils.license_hooks import requires_license
+from utils.logger import logger
 
 class SessionManager:
     @requires_license
@@ -22,8 +23,11 @@ class SessionManager:
         self.actions_log = []
 
         os.makedirs("logs", exist_ok=True)
-        print(
-            f"[SESSION STARTED] ID: {self.session_id} | Mode: {self.mode} | Time: {self.start_time}"
+        logger.info(
+            "[SESSION STARTED] ID: %s | Mode: %s | Time: %s",
+            self.session_id,
+            self.mode,
+            self.start_time,
         )
 
     def set_start_credits(self, credits: int) -> None:
@@ -56,8 +60,10 @@ class SessionManager:
             self.end_xp,
             estimator,
         )
-        print(
-            f"[SESSION ENDED] ID: {self.session_id} | Duration: {self.duration:.2f} mins"
+        logger.info(
+            "[SESSION ENDED] ID: %s | Duration: %.2f mins",
+            self.session_id,
+            self.duration,
         )
         self.save_log()
 
@@ -81,5 +87,5 @@ class SessionManager:
         with open(log_path, "w", encoding="utf-8") as f:
             json.dump(log_data, f, indent=4)
 
-        print(f"[LOG SAVED] \u2192 {log_path}")
+        logger.info("[LOG SAVED] \u2192 %s", log_path)
 

--- a/core/waypoint_verifier.py
+++ b/core/waypoint_verifier.py
@@ -7,6 +7,7 @@ import time
 from typing import Tuple
 
 from src.vision import screen_text
+from utils.logger import logger
 
 _COORD_RE = re.compile(r"(-?\d+)\s*[,:]?\s*(-?\d+)")
 
@@ -35,9 +36,11 @@ def verify_waypoint_stability(coords: Coords, delay: float = 1.0) -> bool:
     end = _detect_position()
     end_dist = _distance(end, coords)
     if end_dist > start_dist:
-        print(
-            f"[WaypointVerifier] Player moved from {start} to {end}; distance increased."
+        logger.info(
+            "[WaypointVerifier] Player moved from %s to %s; distance increased.",
+            start,
+            end,
         )
         return False
-    print(f"[WaypointVerifier] Position stable at {start}.")
+    logger.info("[WaypointVerifier] Position stable at %s.", start)
     return True

--- a/discord_relay.py
+++ b/discord_relay.py
@@ -1,6 +1,7 @@
 import asyncio
 import discord
 from discord.ext import commands
+from utils.logger import logger
 
 
 def generate_ai_reply(sender: str, message: str) -> str:
@@ -22,7 +23,7 @@ class DiscordRelay(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
-        print(f"[DiscordRelay] Connected as {self.bot.user}")
+        logger.info("[DiscordRelay] Connected as %s", self.bot.user)
 
     async def safe_send_user(self, message: str) -> None:
         """Send a DM to the configured user."""
@@ -30,14 +31,14 @@ class DiscordRelay(commands.Cog):
             user = await self.bot.fetch_user(self.target_user_id)
             await user.send(message)
         except discord.HTTPException as e:
-            print(f"[Error] Failed to send DM: {e}")
+            logger.error("[Error] Failed to send DM: %s", e)
 
     async def relay_to_discord(self, sender: str, message: str) -> str | None:
         """Send a whisper to Discord based on the active mode."""
         try:
             user = await self.bot.fetch_user(self.target_user_id)
         except Exception as e:
-            print(f"[Error] Could not fetch user: {e}")
+            logger.error("[Error] Could not fetch user: %s", e)
             return None
 
         if self.mode == "notify":

--- a/game_bridge.py
+++ b/game_bridge.py
@@ -1,6 +1,8 @@
 import asyncio
 from typing import Any
 
+from utils.logger import logger
+
 
 class GameBridge:
     """Simple bridge between the game and the Discord relay."""
@@ -29,6 +31,6 @@ class GameBridge:
 
     def _send_in_game_whisper(self, target: str, text: str) -> None:
         """Placeholder for sending a whisper in-game."""
-        print(f"[GAME] whisper to {target}: {text}")
+        logger.info("[GAME] whisper to %s: %s", target, text)
 
 

--- a/main_discord_bot.py
+++ b/main_discord_bot.py
@@ -4,6 +4,7 @@ import json
 from discord.ext import commands
 
 from discord_relay import DiscordRelay
+from utils.logger import logger
 
 
 def main() -> None:
@@ -16,7 +17,7 @@ def main() -> None:
 
     @bot.event
     async def on_ready() -> None:
-        print(f"[Bot] Logged in as {bot.user}")
+        logger.info("[Bot] Logged in as %s", bot.user)
 
     bot.run(config["discord_token"])
 

--- a/main_state_runner.py
+++ b/main_state_runner.py
@@ -1,18 +1,19 @@
 """Example script demonstrating the ``StateManager``."""
 
 from src.state import StateManager
+from utils.logger import logger
 
 
 def on_mission_board():
-    print("Mission Board detected")
+    logger.info("Mission Board detected")
 
 
 def on_quest_completed():
-    print("Quest completed!")
+    logger.info("Quest completed!")
 
 
 def on_error():
-    print("Error detected!")
+    logger.info("Error detected!")
 
 
 if __name__ == "__main__":

--- a/quest_engine.py
+++ b/quest_engine.py
@@ -1,6 +1,7 @@
 """Simple quest step executor."""
 
 from src.execution.action_router import get_handler
+from utils.logger import logger
 
 
 def handle_quest_step(step: dict) -> bool:
@@ -8,11 +9,11 @@ def handle_quest_step(step: dict) -> bool:
     step_type = step.get("type")
     data = step.get("data", {})
 
-    print(f"[ENGINE] Handling step type: {step_type} with data: {data}")
+    logger.info("[ENGINE] Handling step type: %s with data: %s", step_type, data)
 
     handler = get_handler(step_type)
     if not handler:
-        print(f"[!] Unknown action type: {step_type}")
+        logger.warning("[!] Unknown action type: %s", step_type)
         return False
 
     handler(**data)

--- a/run.py
+++ b/run.py
@@ -6,20 +6,21 @@ sys.path.insert(0, os.path.abspath("."))
 from src.main import main
 from src.db.models import create_schema
 from src.db.queries import select_best_quest
+from utils.logger import logger
 
 if "--init-db" in sys.argv:
-    print("🗃️ Creating database schema...")
+    logger.info("🗃️ Creating database schema...")
     create_schema()
-    print("✅ Database initialized.")
+    logger.info("✅ Database initialized.")
     sys.exit(0)
 
 quest = select_best_quest("Vornax")
 if quest:
-    print("✅ Loaded quest from DB:")
-    print(f"ID: {quest[0]}, Title: {quest[1]}")
-    print(f"Steps: {quest[2]}")
+    logger.info("✅ Loaded quest from DB:")
+    logger.info("ID: %s, Title: %s", quest[0], quest[1])
+    logger.info("Steps: %s", quest[2])
 else:
-    print("⚠️ No suitable quest found.")
+    logger.info("⚠️ No suitable quest found.")
 
 if __name__ == "__main__":
     main()

--- a/run_quest.py
+++ b/run_quest.py
@@ -9,6 +9,7 @@ import yaml
 sys.path.insert(0, os.path.abspath("."))
 
 from src.execution.quest_executor import QuestExecutor
+from utils.logger import logger
 
 
 def load_steps(path: str) -> list[dict]:
@@ -29,7 +30,7 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     steps = load_steps(args.quest_file)
-    print(f"[RUN QUEST] Loaded {len(steps)} steps from {args.quest_file}")
+    logger.info("[RUN QUEST] Loaded %d steps from %s", len(steps), args.quest_file)
 
     executor = QuestExecutor(args.quest_file)
     executor.steps = steps

--- a/tests/test_profession_leveler.py
+++ b/tests/test_profession_leveler.py
@@ -20,8 +20,17 @@ def test_level_all_professions_skips_unknown(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(lvl, "level_profession", lambda prof: calls.append(prof))
 
+    logs = []
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            logs.append(msg % args)
+
+    monkeypatch.setattr("core.profession_leveler.logger", DummyLogger())
+
     lvl.level_all_professions()
     assert calls == ["artisan"]
+    assert "[Leveler] No trainer entry for missing" in logs
 
 
 def test_level_profession_invokes_training(monkeypatch, tmp_path):
@@ -45,8 +54,17 @@ def test_level_profession_invokes_training(monkeypatch, tmp_path):
         lambda prof: tm_calls.setdefault("train", prof),
     )
 
+    logs = []
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            logs.append(msg % args)
+
+    monkeypatch.setattr("core.profession_leveler.logger", DummyLogger())
+
     skills = lvl.level_profession("artisan")
 
     assert tm_calls["train"] == "artisan"
     assert tm_calls["scan"] is True
     assert skills == ["Skill"]
+    assert "[Leveler] artisan trainer offers: ['Skill']" in logs

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -10,6 +10,14 @@ from core.session_manager import SessionManager
 
 def test_session_manager_log_creation(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    log_messages = []
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            log_messages.append(msg % args)
+
+    monkeypatch.setattr("core.session_manager.logger", DummyLogger())
+
     session = SessionManager(mode="test")
     session.set_start_credits(100)
     session.add_action("start")
@@ -22,3 +30,6 @@ def test_session_manager_log_creation(tmp_path, monkeypatch):
     assert data["credits_earned"] == 50
     assert data["actions"][0]["action"] == "start"
     assert data["mode"] == "test"
+    assert any("[SESSION STARTED]" in m for m in log_messages)
+    assert any("[SESSION ENDED]" in m for m in log_messages)
+    assert any("[LOG SAVED]" in m for m in log_messages)

--- a/tests/test_waypoint_verifier.py
+++ b/tests/test_waypoint_verifier.py
@@ -16,8 +16,17 @@ def test_verify_waypoint_stable(monkeypatch):
     monkeypatch.setattr("core.waypoint_verifier._detect_position", fake_detect)
     monkeypatch.setattr("time.sleep", lambda *_: None)
 
+    logs = []
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            logs.append(msg % args)
+
+    monkeypatch.setattr("core.waypoint_verifier.logger", DummyLogger())
+
     assert verify_waypoint_stability((100, 100)) is True
     assert calls["count"] == 2
+    assert "[WaypointVerifier] Position stable at (100, 100)." in logs
 
 
 def test_verify_waypoint_moved(monkeypatch):
@@ -29,4 +38,13 @@ def test_verify_waypoint_moved(monkeypatch):
     monkeypatch.setattr("core.waypoint_verifier._detect_position", fake_detect)
     monkeypatch.setattr("time.sleep", lambda *_: None)
 
+    logs = []
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            logs.append(msg % args)
+
+    monkeypatch.setattr("core.waypoint_verifier.logger", DummyLogger())
+
     assert verify_waypoint_stability((100, 100)) is False
+    assert "distance increased" in logs[0]


### PR DESCRIPTION
## Summary
- replace direct prints with utils.logger usage across core modules
- update main scripts to log instead of printing
- verify log output in tests for profession leveler, session manager and waypoint verifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861f50ae0c88331b753fd0981799223