### PR TITLE
Organize test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,7 @@ data/raw/*.html
 archive/*.html
 
 runtime/
+
+tests/artifacts/
+!tests/artifacts/
+!tests/artifacts/.gitignore

--- a/tests/artifacts/.gitignore
+++ b/tests/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_core_session_tracker.py
+++ b/tests/test_core_session_tracker.py
@@ -1,13 +1,20 @@
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import core.session_tracker as session_tracker
 
+# Directory for persistent test artifacts
+ARTIFACTS_DIR = Path("tests/artifacts")
+ARTIFACTS_DIR.mkdir(exist_ok=True)
+
 
 def test_load_session_default(tmp_path, monkeypatch):
-    session_file = tmp_path / session_tracker.SESSION_FILE
+    session_file = ARTIFACTS_DIR / session_tracker.SESSION_FILE
+    if session_file.exists():
+        session_file.unlink()
     monkeypatch.setenv(session_tracker.SESSION_FILE_ENV, str(session_file))
     assert not session_file.exists()
     data = session_tracker.load_session()
@@ -15,7 +22,9 @@ def test_load_session_default(tmp_path, monkeypatch):
 
 
 def test_save_and_load_roundtrip(tmp_path, monkeypatch):
-    session_file = tmp_path / session_tracker.SESSION_FILE
+    session_file = ARTIFACTS_DIR / session_tracker.SESSION_FILE
+    if session_file.exists():
+        session_file.unlink()
     monkeypatch.setenv(session_tracker.SESSION_FILE_ENV, str(session_file))
     payload = {"foo": 1, "bar": [1, 2, 3]}
     session_tracker.save_session(payload)
@@ -25,7 +34,9 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
 
 
 def test_log_farming_result(tmp_path, monkeypatch):
-    session_file = tmp_path / session_tracker.SESSION_FILE
+    session_file = ARTIFACTS_DIR / session_tracker.SESSION_FILE
+    if session_file.exists():
+        session_file.unlink()
     monkeypatch.setenv(session_tracker.SESSION_FILE_ENV, str(session_file))
 
     monkeypatch.setattr(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+from pathlib import Path
 import pytest
 
 pytest.importorskip("flask")
@@ -8,6 +9,10 @@ pytest.importorskip("flask")
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dashboard.app import app
+
+# Directory for persistent test artifacts
+ARTIFACTS_DIR = Path("tests/artifacts")
+ARTIFACTS_DIR.mkdir(exist_ok=True)
 
 
 def test_builds_route(monkeypatch, tmp_path):
@@ -40,7 +45,9 @@ def test_status_progress_fields(monkeypatch, tmp_path):
     log_file.write_text(json.dumps({}))
     monkeypatch.setattr("dashboard.app.LOG_DIRS", [tmp_path])
 
-    progress_file = tmp_path / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "session_state.json"
+    if progress_file.exists():
+        progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": ["A"]}))
     monkeypatch.setattr("dashboard.app.SESSION_STATE", progress_file)
 

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -1,12 +1,17 @@
 import json
 import os
 import sys
+from pathlib import Path
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import core.profile_loader as profile_loader
 from core.profile_loader import load_profile, validate_profile, ProfileValidationError
+
+# Directory for persistent test artifacts
+ARTIFACTS_DIR = Path("tests/artifacts")
+ARTIFACTS_DIR.mkdir(exist_ok=True)
 
 
 def _patch_runtime(monkeypatch, path):
@@ -36,7 +41,9 @@ def test_load_profile_valid(tmp_path, monkeypatch):
     build_dir = tmp_path / "builds"
     build_dir.mkdir()
     (build_dir / "basic.json").write_text(json.dumps({"skills": []}))
-    progress_file = tmp_path / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "session_state.json"
+    if progress_file.exists():
+        progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": []}))
     monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
     monkeypatch.setattr("core.profile_loader.BUILD_DIR", build_dir)
@@ -70,7 +77,9 @@ def test_load_profile_txt_build(tmp_path, monkeypatch):
     build_dir = tmp_path / "builds"
     build_dir.mkdir()
     (build_dir / "basic.txt").write_text(json.dumps({"skills": ["A"]}))
-    progress_file = tmp_path / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "session_state.json"
+    if progress_file.exists():
+        progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": ["A"]}))
     monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
     monkeypatch.setattr("core.profile_loader.BUILD_DIR", build_dir)
@@ -300,7 +309,9 @@ def test_load_profile_from_repo_txt(tmp_path, monkeypatch):
 
     _patch_runtime(monkeypatch, tmp_path)
 
-    progress_file = tmp_path / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "session_state.json"
+    if progress_file.exists():
+        progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": []}))
     monkeypatch.setattr("core.profile_loader.SESSION_STATE", progress_file)
 


### PR DESCRIPTION
## Summary
- ignore test artifact directory
- place session_state.json outputs under `tests/artifacts`
- clean up tests to use the new artifact location

## Testing
- `pytest tests/test_profile_loader.py::test_load_profile_valid -q`
- `pytest tests/test_dashboard.py::test_status_progress_fields -q`
- `pytest tests/test_core_session_tracker.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686200e9619c8331b1943c2faa266dbc