### PR TITLE
Add distance_limit examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,15 @@ farmer = TerminalFarmer()
 farmer.execute_run()
 ```
 
+The farming profile uses a `distance_limit` key to restrict how far the
+farmer will travel:
+
+```json
+{
+  "distance_limit": 600
+}
+```
+
 Run the farming tests individually with:
 
 ```bash

--- a/docs/modes/farming_mode.md
+++ b/docs/modes/farming_mode.md
@@ -14,6 +14,15 @@ The default profile lives at `config/farming_profile.json` and supports the keys
 - `class_requirements` – list of professions used to filter missions by
   affinity keywords.
 
+Example farming profile:
+
+```json
+{
+  "preferred_terminal": "mission_terminal",
+  "distance_limit": 800
+}
+```
+
 ## Expected Output
 
 `execute_run(board_text=None)` returns a list of missions sorted from the parsed screen text. Each mission is a dictionary with at least:


### PR DESCRIPTION
## Summary
- document distance_limit in Terminal Farming README section
- add JSON snippet demonstrating distance_limit in farming mode docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68620faf89a48331a83291046ecc504f