### PR TITLE
Clarify session state path

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ profile = profile_loader.load_profile("demo")
 update_state(mode=profile.get("default_mode"))
 ```
 
+Session progress defaults to ``runtime/session_state.json``. Set the
+``SESSION_FILE_PATH`` environment variable to use a different location.
+
 ## Discord Relay Bot
 The relay bot depends on the `discord.py` package. Enable it by editing
 `config/config.json` (set `enable_discord_relay`) and

--- a/docs/modes/farming_mode.md
+++ b/docs/modes/farming_mode.md
@@ -33,7 +33,7 @@ Example farming profile:
 - `credits` – optional credit reward if present on the board.
 
 Accepted missions are logged via `core.session_tracker.log_farming_result`,
-updating the session state file (``session_state.json`` by default).
+updating the session state file (``runtime/session_state.json`` by default).
 Set the ``SESSION_FILE_PATH`` environment variable to override this location.
 
 ## Usage Example

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -45,7 +45,8 @@ def test_status_progress_fields(monkeypatch, tmp_path):
     log_file.write_text(json.dumps({}))
     monkeypatch.setattr("dashboard.app.LOG_DIRS", [tmp_path])
 
-    progress_file = ARTIFACTS_DIR / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "runtime" / "session_state.json"
+    progress_file.parent.mkdir(parents=True, exist_ok=True)
     if progress_file.exists():
         progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": ["A"]}))

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -41,7 +41,8 @@ def test_load_profile_valid(tmp_path, monkeypatch):
     build_dir = tmp_path / "builds"
     build_dir.mkdir()
     (build_dir / "basic.json").write_text(json.dumps({"skills": []}))
-    progress_file = ARTIFACTS_DIR / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "runtime" / "session_state.json"
+    progress_file.parent.mkdir(parents=True, exist_ok=True)
     if progress_file.exists():
         progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": []}))
@@ -77,7 +78,8 @@ def test_load_profile_txt_build(tmp_path, monkeypatch):
     build_dir = tmp_path / "builds"
     build_dir.mkdir()
     (build_dir / "basic.txt").write_text(json.dumps({"skills": ["A"]}))
-    progress_file = ARTIFACTS_DIR / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "runtime" / "session_state.json"
+    progress_file.parent.mkdir(parents=True, exist_ok=True)
     if progress_file.exists():
         progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": ["A"]}))
@@ -309,7 +311,8 @@ def test_load_profile_from_repo_txt(tmp_path, monkeypatch):
 
     _patch_runtime(monkeypatch, tmp_path)
 
-    progress_file = ARTIFACTS_DIR / "session_state.json"
+    progress_file = ARTIFACTS_DIR / "runtime" / "session_state.json"
+    progress_file.parent.mkdir(parents=True, exist_ok=True)
     if progress_file.exists():
         progress_file.unlink()
     progress_file.write_text(json.dumps({"completed_skills": []}))


### PR DESCRIPTION
## Summary
- point docs to `runtime/session_state.json`
- record this path in README and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862164cf8f883319e831b8ed4a92210