### PR TITLE
Improve load_profession error handling

### DIFF
--- a/modules/professions/progress_tracker.py
+++ b/modules/professions/progress_tracker.py
@@ -21,8 +21,11 @@ def _skill_name(text: str) -> str:
 def load_profession(profession: str) -> Dict:
     """Load profession data from ``DATA_DIR``."""
     path = DATA_DIR / f"{profession.lower()}.json"
-    with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"Profession data file not found: {path}") from e
 
 
 def has_prerequisites(profession: str, skills: List[str]) -> bool:

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -69,3 +70,12 @@ def test_estimate_hours_to_next_skill(monkeypatch, tmp_path):
         "medic", ["Novice Artisan", "Novice Medic"], "healing"
     )
     assert hours == 1000 / 500
+
+
+def test_load_profession_missing(monkeypatch, tmp_path):
+    """load_profession should raise FileNotFoundError with a helpful message."""
+    monkeypatch.setattr(progress_tracker, "DATA_DIR", tmp_path)
+    expected = tmp_path / "unknown.json"
+    with pytest.raises(FileNotFoundError) as exc:
+        progress_tracker.load_profession("unknown")
+    assert str(exc.value) == f"Profession data file not found: {expected}"


### PR DESCRIPTION
## Summary
- provide clearer error when profession file is missing
- test load_profession missing file behavior

## Testing
- `pytest tests/test_progress_tracker.py -q`


------
https://chatgpt.com/codex/tasks/task_b_686226a017c88331a82621662f252100