### PR TITLE
Add load_profile alias for combat profiles

### DIFF
--- a/modules/combat/__init__.py
+++ b/modules/combat/__init__.py
@@ -1,6 +1,6 @@
 """Combat profile utilities."""
 
-from .profiles import PROFILES_DIR, load_combat_profile
+from .profiles import PROFILES_DIR, load_combat_profile, load_profile
 
-__all__ = ["PROFILES_DIR", "load_combat_profile"]
+__all__ = ["PROFILES_DIR", "load_combat_profile", "load_profile"]
 

--- a/modules/combat/profiles.py
+++ b/modules/combat/profiles.py
@@ -15,3 +15,8 @@ def load_combat_profile(name: str) -> Dict:
     with open(path, "r", encoding="utf-8") as fh:
         return json.load(fh)
 
+
+def load_profile(name: str) -> Dict:
+    """Alias for :func:`load_combat_profile`."""
+    return load_combat_profile(name)
+


### PR DESCRIPTION
## Summary
- expose `load_profile` as alias for `load_combat_profile`
- re-export alias from `modules.combat`

## Testing
- `pytest -q`
- `pytest tests/test_combat_profiles.py::test_load_combat_profile_valid -q`


------
https://chatgpt.com/codex/tasks/task_b_68622cd370c48331a74a2fe3667857a5