### PR TITLE
Handle malformed profile JSON

### DIFF
--- a/core/profile_loader.py
+++ b/core/profile_loader.py
@@ -107,7 +107,10 @@ def load_profile(name: str) -> Dict[str, Any]:
         return {}
 
     with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
+        try:
+            data = json.load(fh)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid profile file: {path}") from exc
 
     profile = validate_profile(data)
     profile["runtime"] = {"progress": load_session()}

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -154,6 +154,15 @@ def test_load_profile_missing(tmp_path, monkeypatch):
     assert prof == {}
 
 
+def test_load_profile_invalid_json(tmp_path, monkeypatch):
+    path = tmp_path / "bad.json"
+    path.write_text("{bad json]")
+    monkeypatch.setattr("core.profile_loader.PROFILE_DIR", tmp_path)
+
+    with pytest.raises(ValueError):
+        load_profile("bad")
+
+
 def test_missing_build_file(tmp_path, monkeypatch):
     data = {
         "support_target": "Leader",


### PR DESCRIPTION
## Summary
- handle malformed JSON when loading profiles
- test ValueError raised on malformed profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68623160fa7c8331a11b6cfa5832eff5