### PR TITLE
Add combat state evaluator and tests

### DIFF
--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,0 +1,1 @@
+"""AI utilities."""

--- a/src/ai/combat/__init__.py
+++ b/src/ai/combat/__init__.py
@@ -1,0 +1,1 @@
+"""Combat AI package."""

--- a/src/ai/combat/evaluator.py
+++ b/src/ai/combat/evaluator.py
@@ -1,0 +1,19 @@
+from typing import Dict
+
+
+def evaluate_state(state: Dict) -> str:
+    """Evaluate the current combat state and return a suggested action."""
+    hp = state.get("player_hp", 100)
+    target_hp = state.get("target_hp", 100)
+    has_healing_item = state.get("has_heal", False)
+    is_buffed = state.get("is_buffed", False)
+
+    if hp < 30 and has_healing_item:
+        return "heal"
+    if hp < 30:
+        return "retreat"
+    if target_hp > 0:
+        return "attack"
+    if not is_buffed:
+        return "buff"
+    return "idle"

--- a/tests/ai/test_evaluator.py
+++ b/tests/ai/test_evaluator.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.ai.combat.evaluator import evaluate_state
+
+
+def test_attack_when_healthy():
+    state = {"player_hp": 80, "target_hp": 50}
+    assert evaluate_state(state) == "attack"
+
+
+def test_heal_when_low_hp_and_heal_item():
+    state = {"player_hp": 20, "target_hp": 50, "has_heal": True}
+    assert evaluate_state(state) == "heal"
+
+
+def test_retreat_when_low_hp_and_no_heal():
+    state = {"player_hp": 20, "target_hp": 50, "has_heal": False}
+    assert evaluate_state(state) == "retreat"
+
+
+def test_buff_when_no_target_and_not_buffed():
+    state = {"player_hp": 100, "target_hp": 0, "is_buffed": False}
+    assert evaluate_state(state) == "buff"
+
+
+def test_idle_when_no_conditions_met():
+    state = {"player_hp": 100, "target_hp": 0, "is_buffed": True}
+    assert evaluate_state(state) == "idle"


### PR DESCRIPTION
## Summary
- add new AI combat module with evaluator
- implement `evaluate_state` function
- create tests covering state evaluation

## Testing
- `pytest -q tests/ai/test_evaluator.py`

------
https://chatgpt.com/codex/tasks/task_b_68623294d97483318f9d0493cc708e4c