### PR TITLE
Add CombatRunner to AI combat

### DIFF
--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,1 +1,5 @@
 """AI utilities."""
+
+from .combat import CombatRunner
+
+__all__ = ["CombatRunner"]

--- a/src/ai/combat/__init__.py
+++ b/src/ai/combat/__init__.py
@@ -1,1 +1,6 @@
 """Combat AI package."""
+
+from .evaluator import evaluate_state
+from .combat_runtime import CombatRunner
+
+__all__ = ["evaluate_state", "CombatRunner"]

--- a/src/ai/combat/combat_runtime.py
+++ b/src/ai/combat/combat_runtime.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from .evaluator import evaluate_state
+
+
+class CombatRunner:
+    """Simple combat runtime wrapper around :func:`evaluate_state`."""
+
+    def tick(self, player_status: Dict, target_status: Dict) -> str:
+        """Return the next action given player and target status."""
+        state = {
+            "player_hp": player_status.get("hp", 100),
+            "has_heal": player_status.get("has_heal", False),
+            "is_buffed": player_status.get("is_buffed", False),
+            "target_hp": target_status.get("hp", 100),
+        }
+        return evaluate_state(state)

--- a/tests/ai/test_combat_runtime.py
+++ b/tests/ai/test_combat_runtime.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.ai.combat.combat_runtime import CombatRunner
+
+
+def test_tick_attack_action():
+    runner = CombatRunner()
+    player = {"hp": 80}
+    target = {"hp": 40}
+    assert runner.tick(player, target) == "attack"
+
+
+def test_tick_heal_action_when_low_hp():
+    runner = CombatRunner()
+    player = {"hp": 15, "has_heal": True}
+    target = {"hp": 60}
+    assert runner.tick(player, target) == "heal"


### PR DESCRIPTION
## Summary
- implement `CombatRunner` with a simple `tick` method
- expose `CombatRunner` from `src.ai.combat` and `src.ai`
- test `CombatRunner` runtime behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686236965b38833197f819b14e652198