### PR TITLE
Refactor combat evaluator signature

### DIFF
--- a/src/ai/combat/combat_runtime.py
+++ b/src/ai/combat/combat_runtime.py
@@ -8,10 +8,4 @@ class CombatRunner:
 
     def tick(self, player_status: Dict, target_status: Dict) -> str:
         """Return the next action given player and target status."""
-        state = {
-            "player_hp": player_status.get("hp", 100),
-            "has_heal": player_status.get("has_heal", False),
-            "is_buffed": player_status.get("is_buffed", False),
-            "target_hp": target_status.get("hp", 100),
-        }
-        return evaluate_state(state)
+        return evaluate_state(player_status, target_status)

--- a/src/ai/combat/evaluator.py
+++ b/src/ai/combat/evaluator.py
@@ -1,12 +1,24 @@
 from typing import Dict
 
 
-def evaluate_state(state: Dict) -> str:
-    """Evaluate the current combat state and return a suggested action."""
-    hp = state.get("player_hp", 100)
-    target_hp = state.get("target_hp", 100)
-    has_healing_item = state.get("has_heal", False)
-    is_buffed = state.get("is_buffed", False)
+def evaluate_state(player_state: Dict, target_state: Dict) -> str:
+    """Evaluate the current combat state and return a suggested action.
+
+    Parameters
+    ----------
+    player_state:
+        Dictionary describing the player's status. Expected keys are
+        ``hp`` (hit points), ``has_heal`` to signal a healing item is
+        available and ``is_buffed`` for whether a buff is active.
+    target_state:
+        Dictionary with the enemy's status. Only ``hp`` is currently
+        consulted.
+    """
+
+    hp = player_state.get("hp", 100)
+    target_hp = target_state.get("hp", 100)
+    has_healing_item = player_state.get("has_heal", False)
+    is_buffed = player_state.get("is_buffed", False)
 
     if hp < 30 and has_healing_item:
         return "heal"

--- a/tests/ai/test_evaluator.py
+++ b/tests/ai/test_evaluator.py
@@ -7,25 +7,30 @@ from src.ai.combat.evaluator import evaluate_state
 
 
 def test_attack_when_healthy():
-    state = {"player_hp": 80, "target_hp": 50}
-    assert evaluate_state(state) == "attack"
+    player = {"hp": 80}
+    target = {"hp": 50}
+    assert evaluate_state(player, target) == "attack"
 
 
 def test_heal_when_low_hp_and_heal_item():
-    state = {"player_hp": 20, "target_hp": 50, "has_heal": True}
-    assert evaluate_state(state) == "heal"
+    player = {"hp": 20, "has_heal": True}
+    target = {"hp": 50}
+    assert evaluate_state(player, target) == "heal"
 
 
 def test_retreat_when_low_hp_and_no_heal():
-    state = {"player_hp": 20, "target_hp": 50, "has_heal": False}
-    assert evaluate_state(state) == "retreat"
+    player = {"hp": 20, "has_heal": False}
+    target = {"hp": 50}
+    assert evaluate_state(player, target) == "retreat"
 
 
 def test_buff_when_no_target_and_not_buffed():
-    state = {"player_hp": 100, "target_hp": 0, "is_buffed": False}
-    assert evaluate_state(state) == "buff"
+    player = {"hp": 100, "is_buffed": False}
+    target = {"hp": 0}
+    assert evaluate_state(player, target) == "buff"
 
 
 def test_idle_when_no_conditions_met():
-    state = {"player_hp": 100, "target_hp": 0, "is_buffed": True}
-    assert evaluate_state(state) == "idle"
+    player = {"hp": 100, "is_buffed": True}
+    target = {"hp": 0}
+    assert evaluate_state(player, target) == "idle"


### PR DESCRIPTION
## Summary
- refactor `evaluate_state` to take `player_state` and `target_state`
- simplify `CombatRunner.tick` to forward both dicts
- adjust evaluator unit tests for the new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686291ea5c808331b37b29caba6c175e