### PR TITLE
Add buff and idle tests for CombatRunner

### DIFF
--- a/tests/ai/test_combat_runtime.py
+++ b/tests/ai/test_combat_runtime.py
@@ -39,3 +39,23 @@ def test_last_action_persists_between_ticks():
     action = runner.tick(player, target)
     assert action == "heal"
     assert runner.last_action == "heal"
+
+
+def test_tick_buff():
+    runner = CombatRunner()
+    player = {"hp": 80, "is_buffed": False}
+    target = {"hp": 0}
+
+    action = runner.tick(player, target)
+    assert action == "buff"
+    assert runner.last_action == "buff"
+
+
+def test_tick_idle():
+    runner = CombatRunner()
+    player = {"hp": 80, "is_buffed": True}
+    target = {"hp": 0}
+
+    action = runner.tick(player, target)
+    assert action == "idle"
+    assert runner.last_action == "idle"


### PR DESCRIPTION
## Summary
- extend CombatRunner tests
- check buff and idle states after target defeat

## Testing
- `pytest tests/ai/test_combat_runtime.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6862b03716388331ba24a505744ea952