### PR TITLE
Fix missing package modules for tests

### DIFF
--- a/ai/combat/__init__.py
+++ b/ai/combat/__init__.py
@@ -1,0 +1,5 @@
+"""Compat module exposing combat AI runtime from ``src.ai``."""
+
+from src.ai.combat import *  # re-export everything for backwards compatibility
+
+__all__ = ["evaluate_state", "CombatRunner"]

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,3 @@
+"""Data package for runtime lookups."""
+
+__all__ = []  # namespace package

--- a/tests/ai/test_combat_runtime.py
+++ b/tests/ai/test_combat_runtime.py
@@ -1,4 +1,5 @@
-from src.ai.combat import CombatRunner
+# Import from the ``ai`` package for consistency with production usage
+from ai.combat import CombatRunner
 
 
 def test_tick_attack_action():

--- a/tests/ai/test_evaluator.py
+++ b/tests/ai/test_evaluator.py
@@ -1,4 +1,5 @@
-from src.ai.combat import evaluate_state
+# Import from the ``ai`` package so tests exercise the installed package path
+from ai.combat import evaluate_state
 
 
 def test_attack_when_healthy():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,13 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
+# Also include the project's ``src`` directory so ``ai`` and other packages
+# resolve the same way they do in production installs.
+SRC_ROOT = os.path.join(ROOT, "src")
+if SRC_ROOT not in sys.path:
+    # Prepend to ensure it takes precedence over any top-level packages
+    sys.path.insert(0, SRC_ROOT)
+
 # Ensure the top-level ``ai`` package resolves during tests
 AI_ROOT = os.path.join(ROOT, "ai")
 if AI_ROOT not in sys.path:


### PR DESCRIPTION
## Summary
- add `ai/combat` module exposing combat runtime utilities
- initialize `data` as a package so imports resolve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862cbcc31cc8331a05ced084ad08fa0