### PR TITLE
Add debug logging to combat evaluator

### DIFF
--- a/src/ai/combat/README.md
+++ b/src/ai/combat/README.md
@@ -29,6 +29,10 @@ from ai.combat import evaluate_state
 
 action = evaluate_state({"hp": 25, "has_heal": True}, {"hp": 50})
 print(action)  # "heal"
+
+# Enable debug logging to understand why a choice was made
+action = evaluate_state({"hp": 25, "has_heal": True}, {"hp": 50}, debug=True)
+# Prints "Decision: heal ..." to stdout
 ```
 
 ## `CombatRunner`

--- a/src/ai/combat/evaluator.py
+++ b/src/ai/combat/evaluator.py
@@ -9,8 +9,11 @@ from .strategies import (
 )
 
 
-def evaluate_state(player_state: Dict, target_state: Dict) -> str:
+def evaluate_state(player_state: Dict, target_state: Dict, debug: bool = False) -> str:
     """Evaluate the current combat state and return a suggested action.
+
+    Set ``debug`` to ``True`` to print the chosen decision and relevant
+    state information. This can help when troubleshooting combat logic.
 
     Parameters
     ----------
@@ -45,13 +48,38 @@ def evaluate_state(player_state: Dict, target_state: Dict) -> str:
     """
 
     if should_heal(player_state):
+        if debug:
+            print(
+                f"Decision: heal (HP low and healing available) | player={player_state} | target={target_state}"
+            )
         return "heal"
     elif should_retreat(player_state):
+        if debug:
+            print(
+                f"Decision: retreat (HP low and no healing available) | player={player_state} | target={target_state}"
+            )
         return "retreat"
     elif should_attack(player_state, target_state):
+        if debug:
+            print(
+                f"Decision: attack (Target alive and player HP sufficient) | player={player_state} | target={target_state}"
+            )
         return "attack"
     elif should_buff(player_state, target_state):
+        if debug:
+            print(
+                f"Decision: buff (Player not buffed and target alive) | player={player_state} | target={target_state}"
+            )
         return "buff"
     elif should_idle(player_state, target_state):
+        if debug:
+            print(
+                f"Decision: idle (Target is dead) | player={player_state} | target={target_state}"
+            )
         return "idle"
+
+    if debug:
+        print(
+            f"Decision: idle (Default/fallback) | player={player_state} | target={target_state}"
+        )
     return "idle"

--- a/tests/ai/test_evaluator.py
+++ b/tests/ai/test_evaluator.py
@@ -54,3 +54,12 @@ def test_defaults_when_is_buffed_missing():
     player = {"hp": 100}
     target = {"hp": 0}
     assert evaluate_state(player, target) == "buff"
+
+
+def test_debug_output(capsys):
+    player = {"hp": 10, "has_heal": True}
+    target = {"hp": 100}
+    action = evaluate_state(player, target, debug=True)
+    captured = capsys.readouterr()
+    assert "Decision: heal" in captured.out
+    assert action == "heal"


### PR DESCRIPTION
## Summary
- add optional debug logging to `evaluate_state`
- document how to enable debug logging in the combat README
- test debug logging output

## Testing
- `pytest tests/ai/test_evaluator.py::test_debug_output -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862d5ccb2588331b6d1c7b271fb1623