### PR TITLE
Fix REQUIRED_SKILLS mapping

### DIFF
--- a/config/profession_config.py
+++ b/config/profession_config.py
@@ -1,8 +1,15 @@
 """Default profession skill requirements and trainer locations."""
 
 REQUIRED_SKILLS = {
-    "artisan": ["Novice Artisan"],
-    "marksman": ["Novice Marksman"],
+    "Artisan": ["crafting_artisan_novice"],
+    "Marksman": ["combat_marksman_novice"],
+    "Medic": ["science_medic_novice"],
+    "Scout": ["outdoors_scout_novice"],
+    "Brawler": ["combat_brawler_novice"],
+    "Entertainer": ["social_entertainer_novice"],
+    "Rifleman": ["combat_rifleman_novice"],
+    "Pistoleer": ["combat_pistoleer_novice"],
+    "Carbineer": ["combat_carbineer_novice"],
 }
 
 from utils.load_trainers import load_trainers

--- a/core/profession_manager.py
+++ b/core/profession_manager.py
@@ -25,7 +25,8 @@ class ProfessionManager:
             if not entries:
                 continue
             entry = entries[0]
-            mapping[profession] = {
+            key = profession.title()
+            mapping[key] = {
                 "planet": entry.get("planet"),
                 "city": entry.get("city"),
                 "coords": entry.get("coords"),

--- a/tests/test_profession_manager.py
+++ b/tests/test_profession_manager.py
@@ -27,14 +27,14 @@ def test_train_missing_skills_travels(monkeypatch):
 
     assert calls["travel"][0][1] == "tatooine"
     assert calls["travel"][0][0] == [3432, -4795]
-    assert calls["interact"][0] == ("Artisan Trainer", "Novice Artisan")
+    assert calls["interact"][0] == ("Artisan Trainer", "crafting_artisan_novice")
 
 
 def test_train_missing_skills_no_action(monkeypatch):
     pm = ProfessionManager()
     monkeypatch.setattr(
         "core.profession_manager.scan_skills_ui",
-        lambda: ["Novice Artisan", "Novice Marksman"],
+        lambda: ["crafting_artisan_novice", "combat_marksman_novice"],
     )
 
     called = False


### PR DESCRIPTION
## Summary
- update REQUIRED_SKILLS to use profession->skill mapping
- normalize trainer map keys to title case
- adjust profession manager tests for new skill names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862f4a7a1608331a6228a0413e3b71f