### PR TITLE
Implement trainer travel automation

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -12,6 +12,7 @@ from .trainer_ocr import (
 from .trainer_scanner import TrainerScanner, scan_trainer_skills
 from .travel_manager import TravelManager
 from .waypoint_verifier import verify_waypoint_stability
+from .trainer_travel import get_travel_macro, start_travel_to_trainer
 from .progress_tracker import load_session, save_session, record_skill
 from .session_tracker import (
     load_session as load_session_state,
@@ -32,6 +33,8 @@ __all__ = [
     "travel_to_target",
     "locate_hotspot",
     "verify_waypoint_stability",
+    "get_travel_macro",
+    "start_travel_to_trainer",
     "load_session",
     "save_session",
     "record_skill",

--- a/core/train_manager.py
+++ b/core/train_manager.py
@@ -2,11 +2,19 @@ import json
 import os
 from utils.travel import travel_to
 from utils.skills import get_player_skills
+from .trainer_travel import start_travel_to_trainer
 
 class TrainManager:
-    def __init__(self, build_path='config/builds/rifleman_medic.json', trainer_db='data/trainers_simple.json'):
+    def __init__(
+        self,
+        build_path: str = 'config/builds/rifleman_medic.json',
+        trainer_db: str = 'data/trainers_simple.json',
+        *,
+        auto_travel: bool = False,
+    ) -> None:
         self.build_path = build_path
         self.trainer_db = trainer_db
+        self.auto_travel = auto_travel
         self.trained_skills = set()
         self.load_build()
 
@@ -20,7 +28,15 @@ class TrainManager:
     def load_trainers(self):
         if os.path.exists(self.trainer_db):
             with open(self.trainer_db, 'r') as f:
-                return json.load(f)
+                data = json.load(f)
+            for entry in data:
+                coords = entry.get('coords') or [entry.get('x'), entry.get('y')]
+                if coords and len(coords) >= 2:
+                    entry['coords'] = [float(coords[0]), float(coords[1])]
+                entry.setdefault('planet', entry.get('zone', 'unknown'))
+                entry.setdefault('city', entry.get('zone', 'unknown'))
+                entry.setdefault('zone', entry.get('city', 'unknown'))
+            return data
         return []
 
     def find_trainer_for_skill(self, skill, current_planet):
@@ -35,6 +51,8 @@ class TrainManager:
         for skill in missing:
             trainer = self.find_trainer_for_skill(skill, current_planet)
             if trainer:
+                if self.auto_travel:
+                    start_travel_to_trainer(trainer)
                 travel_to(trainer['planet'], trainer['city'], trainer['coords'])
                 print(f"[TRAIN] Training {skill} at {trainer['name']} in {trainer['city']}")
                 self.trained_skills.add(skill)

--- a/core/trainer_travel.py
+++ b/core/trainer_travel.py
@@ -1,0 +1,29 @@
+"""Helpers for automating trainer travel via waypoints or macros."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from utils.logger import logger
+
+
+# --------------------------------------------------------------
+def get_travel_macro(trainer: Dict) -> str:
+    """Return a ``/waypoint`` macro string for ``trainer``."""
+    coords = trainer.get("coords") or [trainer.get("x"), trainer.get("y")]
+    if not coords or len(coords) < 2:
+        raise ValueError("trainer missing coordinates")
+    x, y = float(coords[0]), float(coords[1])
+    name = trainer.get("name", "").strip()
+    return f"/waypoint {x} {y} {name}".rstrip()
+
+
+# --------------------------------------------------------------
+def start_travel_to_trainer(trainer: Dict) -> None:
+    """Log the travel macro and simulate execution (placeholder)."""
+    macro = get_travel_macro(trainer)
+    logger.info("[TrainerTravel] Executing macro: %s", macro)
+    print(macro)
+
+
+__all__ = ["get_travel_macro", "start_travel_to_trainer"]

--- a/core/travel_manager.py
+++ b/core/travel_manager.py
@@ -106,3 +106,18 @@ class TravelManager:
 
         skills = self.trainer_scanner.scan()
         return skills
+
+    # --------------------------------------------------
+    def plan_multi_hop_route(
+        self,
+        start_city: str,
+        dest_city: str,
+        *,
+        start_planet: str = "tatooine",
+        dest_planet: str | None = None,
+    ) -> list[dict]:
+        """Placeholder for future pathfinding between cities."""
+        logger.info(
+            "[TravelManager] Multi-hop route planning not implemented yet"
+        )
+        return []

--- a/tests/core/test_trainer_travel.py
+++ b/tests/core/test_trainer_travel.py
@@ -1,0 +1,23 @@
+from core.trainer_travel import get_travel_macro, start_travel_to_trainer
+
+
+def test_get_travel_macro_formats():
+    trainer = {"coords": [1234, -567], "name": "Medic Trainer"}
+    assert get_travel_macro(trainer) == "/waypoint 1234.0 -567.0 Medic Trainer"
+
+
+def test_start_travel_to_trainer_logs(monkeypatch):
+    logs = []
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            logs.append(msg % args)
+
+    import core.trainer_travel as tt
+    monkeypatch.setattr(tt, "logger", DummyLogger())
+    monkeypatch.setattr("builtins.print", lambda *a, **k: None)
+
+    trainer = {"coords": [10, 20], "name": "Trainer"}
+    start_travel_to_trainer(trainer)
+
+    assert any("/waypoint 10.0 20.0 Trainer" in m for m in logs)


### PR DESCRIPTION
## Summary
- add trainer travel utilities to build waypoint macros
- update TrainManager with optional auto-travel support and trainer data normalization
- stub future multi-hop routing in TravelManager
- expose travel helpers via `core.__init__`
- test trainer travel macro formatting and logging

## Testing
- `pytest -q tests/core/test_trainer_travel.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862f6dfe9488331996352467e09d051