### PR TITLE
Add distance field for trainers

### DIFF
--- a/core/train_manager.py
+++ b/core/train_manager.py
@@ -36,6 +36,13 @@ class TrainManager:
                 entry.setdefault('planet', entry.get('zone', 'unknown'))
                 entry.setdefault('city', entry.get('zone', 'unknown'))
                 entry.setdefault('zone', entry.get('city', 'unknown'))
+                if 'distance_to_city' in entry and entry['distance_to_city'] is not None:
+                    try:
+                        entry['distance_to_city'] = float(entry['distance_to_city'])
+                    except (TypeError, ValueError):
+                        entry['distance_to_city'] = 0.0
+                else:
+                    entry.setdefault('distance_to_city', 0.0)
             return data
         return []
 

--- a/data/trainers_simple.json
+++ b/data/trainers_simple.json
@@ -4,20 +4,23 @@
     "skills": ["combat_marksman_novice"],
     "planet": "corellia",
     "city": "coronet",
-    "coords": [ -145, -3556 ]
+    "coords": [ -145, -3556 ],
+    "distance_to_city": 0
   },
   {
     "name": "Mos Eisley Medic Trainer",
     "skills": ["science_medic_novice"],
     "planet": "tatooine",
     "city": "mos_eisley",
-    "coords": [ 3523, -4801 ]
+    "coords": [ 3523, -4801 ],
+    "distance_to_city": 0
   },
   {
     "name": "Theed Rifleman Trainer",
     "skills": ["combat_rifleman_novice"],
     "planet": "naboo",
     "city": "theed",
-    "coords": [ 3322, 555 ]
+    "coords": [ 3322, 555 ],
+    "distance_to_city": 0
   }
 ]

--- a/tests/core/test_train_manager.py
+++ b/tests/core/test_train_manager.py
@@ -9,3 +9,10 @@ def test_train_missing_skills(monkeypatch):
     tm = TrainManager(build_path='config/builds/rifleman_medic.json', trainer_db='data/trainers_simple.json')
     tm.train_missing_skills('tatooine')
     assert "science_medic_novice" in tm.trained_skills
+
+
+def test_load_trainers_distance_field():
+    tm = TrainManager(build_path='config/builds/rifleman_medic.json', trainer_db='data/trainers_simple.json')
+    trainers = tm.load_trainers()
+    assert all('distance_to_city' in t for t in trainers)
+    assert all(isinstance(t['distance_to_city'], float) for t in trainers)


### PR DESCRIPTION
## Summary
- track trainer distance with new `distance_to_city` attribute
- parse `distance_to_city` in `load_trainers`
- check parsed distance in `test_load_trainers_distance_field`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68630f5547748331aac292d9ca23a09b