### PR TITLE
Add travel planning logs to TrainManager

### DIFF
--- a/core/train_manager.py
+++ b/core/train_manager.py
@@ -2,7 +2,8 @@ import json
 import os
 from utils.travel import travel_to
 from utils.skills import get_player_skills
-from .trainer_travel import start_travel_to_trainer
+from utils.logger import logger
+from .trainer_travel import start_travel_to_trainer, plan_travel_to_trainer
 
 class TrainManager:
     def __init__(
@@ -58,10 +59,17 @@ class TrainManager:
         for skill in missing:
             trainer = self.find_trainer_for_skill(skill, current_planet)
             if trainer:
+                steps = plan_travel_to_trainer(trainer)
+                logger.info("[TRAIN] Route plan: %s", steps)
                 if self.auto_travel:
                     start_travel_to_trainer(trainer)
                 travel_to(trainer['planet'], trainer['city'], trainer['coords'])
-                print(f"[TRAIN] Training {skill} at {trainer['name']} in {trainer['city']}")
+                logger.info(
+                    "[TRAIN] Training %s at %s in %s",
+                    skill,
+                    trainer['name'],
+                    trainer['city'],
+                )
                 self.trained_skills.add(skill)
             else:
-                print(f"[TRAIN] No trainer found for skill: {skill}")
+                logger.info("[TRAIN] No trainer found for skill: %s", skill)

--- a/tests/core/test_train_manager.py
+++ b/tests/core/test_train_manager.py
@@ -1,14 +1,25 @@
+import logging
 import pytest
 from core.train_manager import TrainManager
 
 
-def test_train_missing_skills(monkeypatch):
-    monkeypatch.setattr('utils.skills.get_player_skills', lambda: [])
-    monkeypatch.setattr('utils.travel.travel_to', lambda p, c, co: print(f"Mock travel to {c}, {p}, {co}"))
+def test_train_missing_skills(monkeypatch, caplog):
+    monkeypatch.setattr("utils.skills.get_player_skills", lambda: [])
+    monkeypatch.setattr("utils.travel.travel_to", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "core.train_manager.plan_travel_to_trainer",
+        lambda t: ["step1", "step2"],
+    )
 
-    tm = TrainManager(build_path='config/builds/rifleman_medic.json', trainer_db='data/trainers_simple.json')
-    tm.train_missing_skills('tatooine')
+    tm = TrainManager(
+        build_path="config/builds/rifleman_medic.json",
+        trainer_db="data/trainers_simple.json",
+    )
+    with caplog.at_level(logging.INFO, logger="ms11"):
+        tm.train_missing_skills("tatooine")
+
     assert "science_medic_novice" in tm.trained_skills
+    assert any("step1" in rec.message for rec in caplog.records)
 
 
 def test_load_trainers_distance_field():


### PR DESCRIPTION
## Summary
- log plan_travel_to_trainer route steps in TrainManager
- replace print statements with logger usage
- capture route planning logs in TrainManager tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686312f92c98833188d7479a90521ca1