### PR TITLE
Add missing List import

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ import json
 import os
 import threading
 import time
-from typing import Dict, Any, Mapping
+from typing import Dict, Any, Mapping, List
 
 try:
     from discord.ext import commands


### PR DESCRIPTION
## Summary
- add `List` to typing imports in `src/main.py`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6864437f9cf88331ae1563a33b3a5d41