### PR TITLE
Expose legacy tracker and quest engine

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -20,6 +20,8 @@ from .session_tracker import (
     save_session as save_session_state,
     update_session_key,
 )
+from . import legacy_tracker
+from src.execution import quest_engine
 
 __all__ = [
     "preprocess_image",
@@ -43,4 +45,6 @@ __all__ = [
     "load_session_state",
     "save_session_state",
     "update_session_key",
+    "legacy_tracker",
+    "quest_engine",
 ]


### PR DESCRIPTION
## Summary
- re-export `legacy_tracker` and `quest_engine` via `core`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68644b446c10833185f0631547fe4b7e