### PR TITLE
Add legacy quest loop module

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -22,6 +22,9 @@ from .session_tracker import (
 )
 from . import legacy_tracker
 from src.execution import quest_engine
+from .quest_engine import execute_quest_step
+from .legacy_tracker import load_legacy_steps, read_quest_log
+from .legacy_loop import run_full_legacy_quest
 
 __all__ = [
     "preprocess_image",
@@ -47,4 +50,8 @@ __all__ = [
     "update_session_key",
     "legacy_tracker",
     "quest_engine",
+    "execute_quest_step",
+    "load_legacy_steps",
+    "read_quest_log",
+    "run_full_legacy_quest",
 ]

--- a/core/legacy_loop.py
+++ b/core/legacy_loop.py
@@ -1,0 +1,34 @@
+import time
+from typing import List
+
+from utils.logger import logger
+from core.legacy_tracker import load_legacy_steps, read_quest_log
+from core.quest_engine import execute_quest_step
+
+
+def run_full_legacy_quest() -> None:
+    """Execute all legacy quest steps sequentially."""
+    steps = load_legacy_steps()
+    completed_steps = read_quest_log()
+
+    for step in steps:
+        if step.get("id") in completed_steps:
+            continue
+
+        logger.info(
+            f"[Legacy Loop] Executing step: {step.get('id')} - {step.get('description')}"
+        )
+        success = execute_quest_step(step)
+
+        if not success:
+            logger.warning(
+                f"[Legacy Loop] Failed to complete step {step.get('id')}. Halting loop."
+            )
+            break
+
+        logger.info(
+            f"[Legacy Loop] Step {step.get('id')} complete. Waiting before next step..."
+        )
+        time.sleep(3)
+
+    logger.info("[Legacy Loop] Legacy Quest run complete.")

--- a/core/legacy_tracker.py
+++ b/core/legacy_tracker.py
@@ -17,4 +17,18 @@ def load_steps() -> List[Dict[str, Any]]:
         return list(data["steps"])
     return list(data)
 
-__all__ = ["load_steps", "LEGACY_FILE"]
+def load_legacy_steps() -> List[Dict[str, Any]]:
+    """Alias for :func:`load_steps` for backward compatibility."""
+    return load_steps()
+
+
+def read_quest_log() -> List[str]:
+    """Return IDs of completed quest steps from ``logs/quest_log.txt``."""
+    try:
+        with open("logs/quest_log.txt", "r", encoding="utf-8") as f:
+            return [line.strip() for line in f.readlines()]
+    except FileNotFoundError:
+        return []
+
+
+__all__ = ["load_steps", "load_legacy_steps", "read_quest_log", "LEGACY_FILE"]

--- a/core/quest_engine.py
+++ b/core/quest_engine.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for executing quest steps."""
+
+from src.execution.quest_engine import execute_quest_step
+
+__all__ = ["execute_quest_step"]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from core.legacy_loop import run_full_legacy_quest
+
+if __name__ == "__main__":
+    # Option 1: Run full legacy quest loop
+    run_full_legacy_quest()

--- a/tests/test_legacy_loop.py
+++ b/tests/test_legacy_loop.py
@@ -1,0 +1,44 @@
+import types
+import core.legacy_loop as legacy_loop
+
+
+def test_run_full_legacy_quest_executes_all(monkeypatch):
+    steps = [
+        {"id": "1", "description": "first"},
+        {"id": "2", "description": "second"},
+    ]
+    executed = []
+
+    monkeypatch.setattr(legacy_loop, "load_legacy_steps", lambda: steps)
+    monkeypatch.setattr(legacy_loop, "read_quest_log", lambda: [])
+    monkeypatch.setattr(
+        legacy_loop,
+        "execute_quest_step",
+        lambda step: executed.append(step["id"]) or True,
+    )
+    monkeypatch.setattr(legacy_loop, "time", types.SimpleNamespace(sleep=lambda x: None))
+
+    legacy_loop.run_full_legacy_quest()
+    assert executed == ["1", "2"]
+
+
+def test_run_full_legacy_quest_stops_on_failure(monkeypatch):
+    steps = [
+        {"id": "1", "description": "first"},
+        {"id": "2", "description": "second"},
+        {"id": "3", "description": "third"},
+    ]
+    executed = []
+
+    monkeypatch.setattr(legacy_loop, "load_legacy_steps", lambda: steps)
+    monkeypatch.setattr(legacy_loop, "read_quest_log", lambda: [])
+
+    def exec_step(step):
+        executed.append(step["id"])
+        return step["id"] != "2"
+
+    monkeypatch.setattr(legacy_loop, "execute_quest_step", exec_step)
+    monkeypatch.setattr(legacy_loop, "time", types.SimpleNamespace(sleep=lambda x: None))
+
+    legacy_loop.run_full_legacy_quest()
+    assert executed == ["1", "2"]


### PR DESCRIPTION
## Summary
- implement `run_full_legacy_quest` in `core/legacy_loop.py`
- expose `load_legacy_steps` and `read_quest_log` via `core/legacy_tracker`
- export helpers from `core.__init__`
- add compatibility wrapper `core.quest_engine`
- provide simple entrypoint `main.py`
- include tests for the new legacy loop

## Testing
- `pytest -k legacy_loop -q`

------
https://chatgpt.com/codex/tasks/task_b_6864b469723083318f789beed7094e3e