### PR TITLE
Implement case-insensitive planet check

### DIFF
--- a/core/trainer_travel.py
+++ b/core/trainer_travel.py
@@ -31,7 +31,13 @@ def start_travel_to_trainer(trainer: Dict) -> None:
 # --------------------------------------------------------------
 def is_same_planet(trainer: Dict) -> bool:
     """Return ``True`` if the trainer is on the current planet."""
-    return True
+    trainer_planet = trainer.get("planet")
+    current_planet = CURRENT_LOCATION["planet"]
+
+    if not trainer_planet:
+        return False
+
+    return str(trainer_planet).lower() == str(current_planet).lower()
 
 
 # --------------------------------------------------------------

--- a/tests/core/test_trainer_travel.py
+++ b/tests/core/test_trainer_travel.py
@@ -4,6 +4,7 @@ from core.trainer_travel import (
     plan_travel_to_trainer,
     is_same_planet,
 )
+from utils.movement_manager import CURRENT_LOCATION
 
 
 def test_get_travel_macro_formats():
@@ -28,8 +29,14 @@ def test_start_travel_to_trainer_logs(monkeypatch):
     assert any("/waypoint 10.0 20.0 Trainer" in m for m in logs)
 
 
-def test_is_same_planet_returns_true():
-    assert is_same_planet({"planet": "any"}) is True
+def test_is_same_planet_matching(monkeypatch):
+    monkeypatch.setitem(CURRENT_LOCATION, "planet", "tatooine")
+    assert is_same_planet({"planet": "Tatooine"}) is True
+
+
+def test_is_same_planet_nonmatching(monkeypatch):
+    monkeypatch.setitem(CURRENT_LOCATION, "planet", "tatooine")
+    assert is_same_planet({"planet": "naboo"}) is False
 
 
 def test_plan_travel_same_planet(monkeypatch):


### PR DESCRIPTION
## Summary
- implement case-insensitive match for `is_same_planet`
- update trainer travel tests for the new logic

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6864c1c64e448331915bf281f02ad179