### PR TITLE
Add travel macro execution helper

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -12,7 +12,7 @@ from .trainer_ocr import (
 from .trainer_scanner import TrainerScanner, scan_trainer_skills
 from .travel_manager import TravelManager
 from .waypoint_verifier import verify_waypoint_stability
-from .trainer_travel import get_travel_macro, start_travel_to_trainer
+from .trainer_travel import get_travel_macro, execute_travel_macro, start_travel_to_trainer
 from .shuttle_travel import get_shuttle_path
 from .progress_tracker import load_session, save_session, record_skill
 from .session_tracker import (
@@ -40,6 +40,7 @@ __all__ = [
     "locate_hotspot",
     "verify_waypoint_stability",
     "get_travel_macro",
+    "execute_travel_macro",
     "start_travel_to_trainer",
     "get_shuttle_path",
     "load_session",

--- a/core/trainer_travel.py
+++ b/core/trainer_travel.py
@@ -21,11 +21,17 @@ def get_travel_macro(trainer: Dict) -> str:
 
 
 # --------------------------------------------------------------
+def execute_travel_macro(macro: str) -> None:
+    """Log and execute the travel macro (placeholder)."""
+    logger.info("[TrainerTravel] Executing macro: %s", macro)
+    print(macro)
+
+
+# --------------------------------------------------------------
 def start_travel_to_trainer(trainer: Dict) -> None:
     """Log the travel macro and simulate execution (placeholder)."""
     macro = get_travel_macro(trainer)
-    logger.info("[TrainerTravel] Executing macro: %s", macro)
-    print(macro)
+    execute_travel_macro(macro)
 
 
 # --------------------------------------------------------------
@@ -59,6 +65,7 @@ def plan_travel_to_trainer(trainer: Dict) -> List[str]:
 
 __all__ = [
     "get_travel_macro",
+    "execute_travel_macro",
     "start_travel_to_trainer",
     "is_same_planet",
     "plan_travel_to_trainer",

--- a/tests/core/test_trainer_travel.py
+++ b/tests/core/test_trainer_travel.py
@@ -1,5 +1,6 @@
 from core.trainer_travel import (
     get_travel_macro,
+    execute_travel_macro,
     start_travel_to_trainer,
     plan_travel_to_trainer,
     is_same_planet,
@@ -27,6 +28,22 @@ def test_start_travel_to_trainer_logs(monkeypatch):
     start_travel_to_trainer(trainer)
 
     assert any("/waypoint 10.0 20.0 Trainer" in m for m in logs)
+
+
+def test_execute_travel_macro_logs(monkeypatch):
+    logs = []
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            logs.append(msg % args)
+
+    import core.trainer_travel as tt
+    monkeypatch.setattr(tt, "logger", DummyLogger())
+    monkeypatch.setattr("builtins.print", lambda *a, **k: None)
+
+    execute_travel_macro("/waypoint 1 2 Trainer")
+
+    assert any("/waypoint 1 2 Trainer" in m for m in logs)
 
 
 def test_is_same_planet_matching(monkeypatch):


### PR DESCRIPTION
## Summary
- add `execute_travel_macro` for logging and executing macros
- re-export helper in `core.__init__`
- use new helper inside `start_travel_to_trainer`
- verify macro logging via new unit test

## Testing
- `pytest -q tests/core/test_trainer_travel.py`

------
https://chatgpt.com/codex/tasks/task_b_6864c333694883319d6b7cdf06995444