### PR TITLE
Expose travel planner utilities via core

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -12,7 +12,13 @@ from .trainer_ocr import (
 from .trainer_scanner import TrainerScanner, scan_trainer_skills
 from .travel_manager import TravelManager
 from .waypoint_verifier import verify_waypoint_stability
-from .trainer_travel import get_travel_macro, execute_travel_macro, start_travel_to_trainer
+from .trainer_travel import (
+    get_travel_macro,
+    execute_travel_macro,
+    start_travel_to_trainer,
+    plan_travel_to_trainer,
+    is_same_planet,
+)
 from .shuttle_travel import get_shuttle_path
 from .progress_tracker import load_session, save_session, record_skill
 from .session_tracker import (
@@ -42,6 +48,8 @@ __all__ = [
     "get_travel_macro",
     "execute_travel_macro",
     "start_travel_to_trainer",
+    "plan_travel_to_trainer",
+    "is_same_planet",
     "get_shuttle_path",
     "load_session",
     "save_session",

--- a/tests/core/test_trainer_travel.py
+++ b/tests/core/test_trainer_travel.py
@@ -1,4 +1,4 @@
-from core.trainer_travel import (
+from core import (
     get_travel_macro,
     execute_travel_macro,
     start_travel_to_trainer,


### PR DESCRIPTION
## Summary
- expose `plan_travel_to_trainer` and `is_same_planet` in `core.__init__`
- re-export new `execute_travel_macro`
- update tests to import trainer travel helpers from `core`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6864c79ea578833186aaa066ab04324b