### PR TITLE
Add quest log utilities

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -31,6 +31,12 @@ from src.execution import quest_engine
 from .quest_engine import execute_quest_step
 from .legacy_tracker import load_legacy_steps, read_quest_log
 from .legacy_loop import run_full_legacy_quest
+from .quest_state import (
+    parse_quest_log,
+    is_step_completed,
+    scan_log_file_for_step,
+    extract_quest_log_from_screenshot,
+)
 
 __all__ = [
     "preprocess_image",
@@ -63,4 +69,8 @@ __all__ = [
     "load_legacy_steps",
     "read_quest_log",
     "run_full_legacy_quest",
+    "parse_quest_log",
+    "is_step_completed",
+    "scan_log_file_for_step",
+    "extract_quest_log_from_screenshot",
 ]

--- a/core/quest_state.py
+++ b/core/quest_state.py
@@ -1,0 +1,47 @@
+"""Utilities for parsing quest log text and checking quest progress."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+def parse_quest_log(log_text: str) -> List[str]:
+    """Return cleaned lines from a quest log ``log_text``."""
+    lines: List[str] = []
+    for line in log_text.splitlines():
+        line = line.strip()
+        if line:
+            lines.append(line)
+    return lines
+
+
+def is_step_completed(log_text: str, step_text: str) -> bool:
+    """Return ``True`` if ``step_text`` appears in ``log_text``."""
+    step = step_text.lower()
+    for line in parse_quest_log(log_text):
+        if step in line.lower():
+            return True
+    return False
+
+
+def scan_log_file_for_step(log_path: str, step_text: str) -> bool:
+    """Return ``True`` if ``step_text`` is found in the file at ``log_path``."""
+    try:
+        data = Path(log_path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+    return is_step_completed(data, step_text)
+
+
+def extract_quest_log_from_screenshot(image_path: str) -> str:
+    """Extract quest log text from a screenshot. Stub implementation."""
+    return ""
+
+
+__all__ = [
+    "parse_quest_log",
+    "is_step_completed",
+    "scan_log_file_for_step",
+    "extract_quest_log_from_screenshot",
+]

--- a/tests/test_quest_state.py
+++ b/tests/test_quest_state.py
@@ -1,0 +1,12 @@
+import core.quest_state as qs
+
+
+def test_parse_quest_log_strips_and_filters_lines():
+    text = "\nStep one\n\n  Step two  \nStep three\n"
+    assert qs.parse_quest_log(text) == ["Step one", "Step two", "Step three"]
+
+
+def test_is_step_completed_case_insensitive():
+    text = "Gather items\nReturn to Base\n"
+    assert qs.is_step_completed(text, "return to base") is True
+    assert qs.is_step_completed(text, "missing step") is False


### PR DESCRIPTION
## Summary
- implement `quest_state` helpers for reading quest logs
- expose helpers in `core.__init__`
- test quest log parsing and completion detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864d13fb58483318f3e3747c13388e4