### PR TITLE
Add legacy dashboard progress display

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -31,6 +31,7 @@ from src.execution import quest_engine
 from .quest_engine import execute_quest_step
 from .legacy_tracker import load_legacy_steps, read_quest_log
 from .legacy_loop import run_full_legacy_quest
+from .legacy_dashboard import display_legacy_progress
 from .quest_state import (
     parse_quest_log,
     is_step_completed,
@@ -69,6 +70,7 @@ __all__ = [
     "load_legacy_steps",
     "read_quest_log",
     "run_full_legacy_quest",
+    "display_legacy_progress",
     "parse_quest_log",
     "is_step_completed",
     "scan_log_file_for_step",

--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -1,0 +1,30 @@
+"""Utilities for displaying legacy quest progress."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.table import Table
+
+from .legacy_tracker import load_legacy_steps, read_quest_log
+
+
+def display_legacy_progress() -> None:
+    """Print a table of legacy quest steps and completion status."""
+    steps = load_legacy_steps()
+    completed = set(read_quest_log())
+
+    table = Table(title="Legacy Quest Progress")
+    table.add_column("ID", style="bold", no_wrap=True)
+    table.add_column("Title")
+    table.add_column("Completed", justify="center")
+
+    for step in steps:
+        step_id = str(step.get("id"))
+        title = step.get("title") or step.get("description", "")
+        status = "Yes" if step_id in completed else "No"
+        table.add_row(step_id, title, status)
+
+    Console().print(table)
+
+
+__all__ = ["display_legacy_progress"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyautogui
 Pillow
 numpy
 pygetwindow
+rich

--- a/tests/test_legacy_dashboard.py
+++ b/tests/test_legacy_dashboard.py
@@ -1,0 +1,14 @@
+import core.legacy_dashboard as legacy_dashboard
+
+
+def test_display_legacy_progress(monkeypatch):
+    monkeypatch.setattr(
+        legacy_dashboard,
+        "load_legacy_steps",
+        lambda: [
+            {"id": 1, "title": "First"},
+            {"id": 2, "title": "Second"},
+        ],
+    )
+    monkeypatch.setattr(legacy_dashboard, "read_quest_log", lambda: ["1"])
+    legacy_dashboard.display_legacy_progress()


### PR DESCRIPTION
## Summary
- implement `display_legacy_progress` using `rich` table output
- expose the function from `core.__init__`
- add dependency on `rich`
- test calling `display_legacy_progress`

## Testing
- `pip install rich`
- `pytest tests/test_legacy_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6864d61bc9a08331810ab1a2357eec65