### PR TITLE
Add quest log utilities and status helpers

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -37,6 +37,8 @@ from .quest_state import (
     is_step_completed,
     scan_log_file_for_step,
     extract_quest_log_from_screenshot,
+    read_saved_quest_log,
+    get_step_status,
 )
 
 __all__ = [
@@ -75,4 +77,6 @@ __all__ = [
     "is_step_completed",
     "scan_log_file_for_step",
     "extract_quest_log_from_screenshot",
+    "read_saved_quest_log",
+    "get_step_status",
 ]

--- a/core/quest_state.py
+++ b/core/quest_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import List, Dict
 
 
 def parse_quest_log(log_text: str) -> List[str]:
@@ -39,9 +39,32 @@ def extract_quest_log_from_screenshot(image_path: str) -> str:
     return ""
 
 
+def read_saved_quest_log() -> List[str]:
+    """Return cleaned quest log lines from ``logs/quest_log.txt``."""
+    path = Path("logs") / "quest_log.txt"
+    try:
+        data = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    return parse_quest_log(data)
+
+
+def get_step_status(step: Dict) -> str:
+    """Return a status string for ``step`` based on the saved quest log."""
+    completed = set(read_saved_quest_log())
+    step_id = step.get("id")
+    if step_id is not None and str(step_id) in completed:
+        return "✅ Completed"
+    if step.get("active"):
+        return "🕒 Active"
+    return "⏭️ Pending"
+
+
 __all__ = [
     "parse_quest_log",
     "is_step_completed",
     "scan_log_file_for_step",
     "extract_quest_log_from_screenshot",
+    "read_saved_quest_log",
+    "get_step_status",
 ]

--- a/tests/test_quest_state.py
+++ b/tests/test_quest_state.py
@@ -10,3 +10,26 @@ def test_is_step_completed_case_insensitive():
     text = "Gather items\nReturn to Base\n"
     assert qs.is_step_completed(text, "return to base") is True
     assert qs.is_step_completed(text, "missing step") is False
+
+
+def test_read_saved_quest_log(tmp_path, monkeypatch):
+    log_file = tmp_path / "logs" / "quest_log.txt"
+    log_file.parent.mkdir()
+    log_file.write_text("\n1\n 2 \n3\n")
+    monkeypatch.chdir(tmp_path)
+    assert qs.read_saved_quest_log() == ["1", "2", "3"]
+
+
+def test_get_step_status(tmp_path, monkeypatch):
+    log_file = tmp_path / "logs" / "quest_log.txt"
+    log_file.parent.mkdir()
+    log_file.write_text("1\n")
+    monkeypatch.chdir(tmp_path)
+
+    step_completed = {"id": "1"}
+    step_active = {"id": "2", "active": True}
+    step_pending = {"id": "3"}
+
+    assert qs.get_step_status(step_completed) == "✅ Completed"
+    assert qs.get_step_status(step_active) == "🕒 Active"
+    assert qs.get_step_status(step_pending) == "⏭️ Pending"


### PR DESCRIPTION
## Summary
- extend `core.quest_state` with `read_saved_quest_log` and `get_step_status`
- re-export new helpers from `core` package
- test quest state helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68655516af4883319232e025c0db3ea4