### PR TITLE
Add argparse CLI for legacy runner

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,40 @@
+"""CLI entry point for legacy quest utilities."""
+
+from __future__ import annotations
+
+import argparse
+
 from core.legacy_loop import run_full_legacy_quest
+from core.legacy_dashboard import display_legacy_progress
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed command line arguments."""
+    parser = argparse.ArgumentParser(description="Legacy quest utilities")
+    parser.add_argument(
+        "--legacy",
+        action="store_true",
+        help="Run the full legacy quest loop",
+    )
+    parser.add_argument(
+        "--show-legacy-status",
+        dest="show_legacy_status",
+        action="store_true",
+        help="Display current legacy quest progress",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Execute actions based on CLI flags."""
+    args = parse_args(argv)
+
+    if args.show_legacy_status:
+        display_legacy_progress()
+
+    if args.legacy or not (args.legacy or args.show_legacy_status):
+        run_full_legacy_quest()
+
 
 if __name__ == "__main__":
-    # Option 1: Run full legacy quest loop
-    run_full_legacy_quest()
+    main()

--- a/tests/test_main_legacy_cli.py
+++ b/tests/test_main_legacy_cli.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+
+import main as legacy_main
+
+
+def test_parse_args_legacy(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--legacy"])
+    args = legacy_main.parse_args()
+    assert args.legacy is True
+    assert args.show_legacy_status is False
+
+
+def test_parse_args_show_status(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--show-legacy-status"])
+    args = legacy_main.parse_args()
+    assert args.show_legacy_status is True
+    assert args.legacy is False
+
+
+def test_main_runs_legacy_by_default(monkeypatch):
+    legacy_main_mod = importlib.reload(legacy_main)
+    called = {}
+    monkeypatch.setattr(legacy_main_mod, "run_full_legacy_quest", lambda: called.setdefault("legacy", True))
+    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda: called.setdefault("status", True))
+    legacy_main_mod.main([])
+    assert called.get("legacy") is True
+    assert "status" not in called
+
+
+def test_main_show_status_only(monkeypatch):
+    legacy_main_mod = importlib.reload(legacy_main)
+    called = []
+    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda: called.append("status"))
+    monkeypatch.setattr(legacy_main_mod, "run_full_legacy_quest", lambda: called.append("legacy"))
+    legacy_main_mod.main(["--show-legacy-status"])
+    assert called == ["status"]
+


### PR DESCRIPTION
## Summary
- add argparse handling to `main.py` with `--legacy` and `--show-legacy-status`
- keep backward compatibility for default execution
- add tests verifying new CLI behaviour

## Testing
- `pytest tests/test_main_legacy_cli.py tests/test_legacy_loop.py tests/test_legacy_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686556f3315c83319485c0300a89cd8d