### PR TITLE
Use quest_state for legacy dashboard status

### DIFF
--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -5,23 +5,23 @@ from __future__ import annotations
 from rich.console import Console
 from rich.table import Table
 
-from .legacy_tracker import load_legacy_steps, read_quest_log
+from .legacy_tracker import load_legacy_steps
+from .quest_state import get_step_status
 
 
 def display_legacy_progress() -> None:
     """Print a table of legacy quest steps and completion status."""
     steps = load_legacy_steps()
-    completed = set(read_quest_log())
 
     table = Table(title="Legacy Quest Progress")
     table.add_column("ID", style="bold", no_wrap=True)
     table.add_column("Title")
-    table.add_column("Completed", justify="center")
+    table.add_column("Status", justify="center")
 
     for step in steps:
         step_id = str(step.get("id"))
         title = step.get("title") or step.get("description", "")
-        status = "Yes" if step_id in completed else "No"
+        status = get_step_status(step)
         table.add_row(step_id, title, status)
 
     Console().print(table)

--- a/tests/test_legacy_dashboard.py
+++ b/tests/test_legacy_dashboard.py
@@ -1,4 +1,5 @@
 import core.legacy_dashboard as legacy_dashboard
+import core.quest_state as qs
 
 
 def test_display_legacy_progress(monkeypatch, capsys):
@@ -10,8 +11,8 @@ def test_display_legacy_progress(monkeypatch, capsys):
             {"id": 2, "title": "Second"},
         ],
     )
-    monkeypatch.setattr(legacy_dashboard, "read_quest_log", lambda: ["1"])
+    monkeypatch.setattr(qs, "read_saved_quest_log", lambda: ["1"])
     legacy_dashboard.display_legacy_progress()
     captured = capsys.readouterr()
-    assert "Yes" in captured.out
-    assert "No" in captured.out
+    assert "✅ Completed" in captured.out
+    assert "⏭️ Pending" in captured.out


### PR DESCRIPTION
## Summary
- use `get_step_status` to compute legacy quest step status
- show updated status output in `display_legacy_progress`
- adjust unit test for the new status strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68657803a908833190cc3c06aadfe56e