### PR TITLE
Add explicit legacy flag CLI test

### DIFF
--- a/tests/test_main_legacy_cli.py
+++ b/tests/test_main_legacy_cli.py
@@ -36,3 +36,13 @@ def test_main_show_status_only(monkeypatch):
     legacy_main_mod.main(["--show-legacy-status"])
     assert called == ["status"]
 
+
+def test_main_legacy_flag(monkeypatch):
+    legacy_main_mod = importlib.reload(legacy_main)
+    called = {}
+    monkeypatch.setattr(legacy_main_mod, "run_full_legacy_quest", lambda: called.setdefault("legacy", True))
+    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda: called.setdefault("status", True))
+    legacy_main_mod.main(["--legacy"])
+    assert called.get("legacy") is True
+    assert "status" not in called
+


### PR DESCRIPTION
## Summary
- improve legacy CLI test coverage
- ensure `--legacy` calls the appropriate function and does not display progress

## Testing
- `pytest tests/test_main_legacy_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6865874fdffc8331854a2f602837b365