### PR TITLE
Use retry helper in legacy loop

### DIFF
--- a/core/legacy_loop.py
+++ b/core/legacy_loop.py
@@ -3,7 +3,7 @@ from typing import List
 
 from utils.logger import logger
 from core.legacy_tracker import load_legacy_steps, read_quest_log
-from core.quest_engine import execute_quest_step
+from core.quest_engine import execute_with_retry
 
 
 def run_full_legacy_quest() -> None:
@@ -18,7 +18,7 @@ def run_full_legacy_quest() -> None:
         logger.info(
             f"[Legacy Loop] Executing step: {step.get('id')} - {step.get('description')}"
         )
-        success = execute_quest_step(step)
+        success = execute_with_retry(step, max_retries=3)
 
         if not success:
             logger.warning(

--- a/tests/test_legacy_loop.py
+++ b/tests/test_legacy_loop.py
@@ -13,8 +13,8 @@ def test_run_full_legacy_quest_executes_all(monkeypatch):
     monkeypatch.setattr(legacy_loop, "read_quest_log", lambda: [])
     monkeypatch.setattr(
         legacy_loop,
-        "execute_quest_step",
-        lambda step: executed.append(step["id"]) or True,
+        "execute_with_retry",
+        lambda step, max_retries=3: executed.append(step["id"]) or True,
     )
     monkeypatch.setattr(legacy_loop, "time", types.SimpleNamespace(sleep=lambda x: None))
 
@@ -37,7 +37,7 @@ def test_run_full_legacy_quest_stops_on_failure(monkeypatch):
         executed.append(step["id"])
         return step["id"] != "2"
 
-    monkeypatch.setattr(legacy_loop, "execute_quest_step", exec_step)
+    monkeypatch.setattr(legacy_loop, "execute_with_retry", lambda step, max_retries=3: exec_step(step))
     monkeypatch.setattr(legacy_loop, "time", types.SimpleNamespace(sleep=lambda x: None))
 
     legacy_loop.run_full_legacy_quest()


### PR DESCRIPTION
## Summary
- run legacy quest steps with `execute_with_retry`
- update tests for the new helper

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6865e89786c4833181a17e950ee661f5