### PR TITLE
Add retry logging helper

### DIFF
--- a/core/quest_engine.py
+++ b/core/quest_engine.py
@@ -12,13 +12,16 @@ RETRY_LOG_PATH = os.path.join("logs", "retry_log.txt")
 
 
 def log_retry(step_id: str, attempt: int, error: Exception | str) -> None:
-    """Append a retry event to :data:`RETRY_LOG_PATH`."""
+    """Append a retry event to :data:`RETRY_LOG_PATH`.
+
+    The log file uses a simple CSV format: ``timestamp, step_id, attempt, error``.
+    """
 
     os.makedirs(os.path.dirname(RETRY_LOG_PATH), exist_ok=True)
     timestamp = datetime.utcnow().isoformat()
     message = str(error)
     with open(RETRY_LOG_PATH, "a", encoding="utf-8") as fh:
-        fh.write(f"{timestamp} | {step_id} | attempt {attempt} | {message}\n")
+        fh.write(f"{timestamp}, {step_id}, {attempt}, {message}\n")
 
 
 def execute_with_retry(

--- a/tests/test_quest_engine_retry.py
+++ b/tests/test_quest_engine_retry.py
@@ -1,0 +1,18 @@
+import os
+from core import quest_engine
+
+def test_log_retry_creates_csv(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_file = log_dir / "retry_log.txt"
+    monkeypatch.setattr(quest_engine, "RETRY_LOG_PATH", str(log_file))
+
+    quest_engine.log_retry("step1", 1, "boom")
+
+    assert log_dir.is_dir()
+    assert log_file.exists()
+    line = log_file.read_text(encoding="utf-8").strip()
+    parts = line.split(', ')
+    assert len(parts) == 4
+    assert parts[1] == "step1"
+    assert parts[2] == "1"
+    assert parts[3] == "boom"


### PR DESCRIPTION
## Summary
- add `log_retry` helper to `core/quest_engine` to record retries
- create test verifying retry logs are written correctly

## Testing
- `pytest tests/test_quest_engine_retry.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6865f091227c833186932900f763c58c