### PR TITLE
Update retry logic tests

### DIFF
--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -1,23 +1,70 @@
+import os
 import core.quest_engine as quest_engine
+import pytest
 
 
-def test_execute_with_retry_retries_and_logs(monkeypatch):
+@pytest.fixture(autouse=True)
+def clear_retry_log():
+    """Remove the retry log before each test."""
+    path = quest_engine.RETRY_LOG_PATH
+    if os.path.exists(path):
+        os.remove(path)
+    yield
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def _read_log_lines():
+    path = quest_engine.RETRY_LOG_PATH
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as fh:
+        return [line for line in fh.read().splitlines() if line]
+
+
+def test_success_first_try(monkeypatch):
     calls = []
-    def fake_step(step):
-        calls.append(step)
-        return len(calls) >= 3
+
+    def fake_step(step_id):
+        calls.append(step_id)
+        return True
 
     monkeypatch.setattr(quest_engine, "execute_quest_step", fake_step)
-    log_calls = []
-    def fake_log(step_id, attempt, error):
-        log_calls.append((step_id, attempt, str(error)))
-    monkeypatch.setattr(quest_engine, "log_retry", fake_log)
 
-    result = quest_engine.execute_with_retry("step", max_retries=5)
+    result = quest_engine.execute_with_retry("step", max_retries=3)
 
     assert result is True
+    assert len(calls) == 1
+    assert _read_log_lines() == []
+
+
+def test_fail_once_then_success(monkeypatch):
+    calls = []
+
+    def fake_step(step_id):
+        calls.append(step_id)
+        return len(calls) >= 2
+
+    monkeypatch.setattr(quest_engine, "execute_quest_step", fake_step)
+
+    result = quest_engine.execute_with_retry("step", max_retries=3)
+
+    assert result is True
+    assert len(calls) == 2
+    assert len(_read_log_lines()) == 1
+
+
+def test_always_fail(monkeypatch):
+    calls = []
+
+    def fake_step(step_id):
+        calls.append(step_id)
+        return False
+
+    monkeypatch.setattr(quest_engine, "execute_quest_step", fake_step)
+
+    result = quest_engine.execute_with_retry("step", max_retries=3)
+
+    assert result is False
     assert len(calls) == 3
-    assert log_calls == [
-        ("step", 1, "false result"),
-        ("step", 2, "false result"),
-    ]
+    assert len(_read_log_lines()) == 3


### PR DESCRIPTION
## Summary
- replace `tests/test_retry_logic.py` with new tests
- add fixture to clear retry log before each test
- verify correct call counts and log entries for success, partial failure and total failure

## Testing
- `pytest tests/test_retry_logic.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686618082e54833181919c1e67dab6ac