### PR TITLE
Fix log_retry signature

### DIFF
--- a/core/quest_engine.py
+++ b/core/quest_engine.py
@@ -11,17 +11,17 @@ from src.execution.quest_engine import execute_quest_step
 RETRY_LOG_PATH = os.path.join("logs", "retry_log.txt")
 
 
-def log_retry(step_id: str, attempt: int, error: Exception | str) -> None:
+def log_retry(step_label: str, attempt: int, error: Exception | str) -> None:
     """Append a retry event to :data:`RETRY_LOG_PATH`.
 
-    The log file uses a simple CSV format: ``timestamp, step_id, attempt, error``.
+    The log file uses a simple CSV format: ``timestamp, step_label, attempt, error``.
     """
 
     os.makedirs(os.path.dirname(RETRY_LOG_PATH), exist_ok=True)
     timestamp = datetime.utcnow().isoformat()
     message = str(error)
     with open(RETRY_LOG_PATH, "a", encoding="utf-8") as fh:
-        fh.write(f"{timestamp}, {step_id}, {attempt}, {message}\n")
+        fh.write(f"{timestamp}, {step_label}, {attempt}, {message}\n")
 
 
 def execute_with_retry(


### PR DESCRIPTION
## Summary
- update `core/quest_engine.log_retry` parameter to `step_label`
- reflect new name in docstring and message construction

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68662309392c8331b941401ba3b11d69