### PR TITLE
Add fallback coverage to execute_with_retry

### DIFF
--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -68,3 +68,27 @@ def test_always_fail(monkeypatch):
     assert result is False
     assert len(calls) == 3
     assert len(_read_log_lines()) == 3
+
+
+def test_always_fail_with_fallback(monkeypatch):
+    """Fallback should run once after all retries fail."""
+    step_calls = []
+    fallback_calls = []
+
+    def fake_step(step):
+        step_calls.append(step)
+        return False
+
+    def fake_fallback(step):
+        fallback_calls.append(step)
+        return True
+
+    monkeypatch.setattr(quest_engine, "execute_quest_step", fake_step)
+
+    result = quest_engine.execute_with_retry(
+        "step", max_retries=3, fallback=fake_fallback
+    )
+
+    assert result is True
+    assert len(step_calls) == 3
+    assert fallback_calls == ["step"]


### PR DESCRIPTION
## Summary
- extend tests for execute_with_retry to cover fallback logic

## Testing
- `pytest tests/test_retry_logic.py::test_always_fail_with_fallback -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686624465a9c833197f5ab273b2a2b92