### PR TITLE
Update quest log utilities

### DIFF
--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -21,7 +21,7 @@ def display_legacy_progress() -> None:
     for step in steps:
         step_id = str(step.get("id"))
         title = step.get("title") or step.get("description", "")
-        status = get_step_status(step)
+        status = get_step_status(step_id)
         table.add_row(step_id, title, status)
 
     Console().print(table)

--- a/core/quest_state.py
+++ b/core/quest_state.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Optional
+
+# Default path for the saved quest log
+QUEST_LOG_PATH = "logs/quest_log.txt"
 
 
 def parse_quest_log(log_text: str) -> List[str]:
@@ -40,8 +43,8 @@ def extract_quest_log_from_screenshot(image_path: str) -> str:
 
 
 def read_saved_quest_log() -> List[str]:
-    """Return cleaned quest log lines from ``logs/quest_log.txt``."""
-    path = Path("logs") / "quest_log.txt"
+    """Return cleaned quest log lines from ``QUEST_LOG_PATH``."""
+    path = Path(QUEST_LOG_PATH)
     try:
         data = path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -49,15 +52,22 @@ def read_saved_quest_log() -> List[str]:
     return parse_quest_log(data)
 
 
-def get_step_status(step: Dict) -> str:
-    """Return a status string for ``step`` based on the saved quest log."""
-    completed = set(read_saved_quest_log())
-    step_id = step.get("id")
-    if step_id is not None and str(step_id) in completed:
-        return "✅ Completed"
-    if step.get("active"):
-        return "🕒 Active"
-    return "⏭️ Pending"
+def get_step_status(step_id: str, log_lines: Optional[List[str]] = None) -> str:
+    """Return a status string for ``step_id`` by scanning quest log lines."""
+    if log_lines is None:
+        log_lines = read_saved_quest_log()
+
+    step_id = str(step_id).lower()
+    for line in log_lines:
+        lowered = line.lower()
+        if step_id in lowered:
+            if "failed" in lowered:
+                return "❌ Failed"
+            if "complete" in lowered:
+                return "✅ Completed"
+            if "progress" in lowered or "started" in lowered or "in progress" in lowered:
+                return "⏳ In Progress"
+    return "❓ Unknown"
 
 
 __all__ = [

--- a/tests/test_legacy_dashboard.py
+++ b/tests/test_legacy_dashboard.py
@@ -11,8 +11,8 @@ def test_display_legacy_progress(monkeypatch, capsys):
             {"id": 2, "title": "Second"},
         ],
     )
-    monkeypatch.setattr(qs, "read_saved_quest_log", lambda: ["1"])
+    monkeypatch.setattr(qs, "read_saved_quest_log", lambda: ["quest 1 completed"])
     legacy_dashboard.display_legacy_progress()
     captured = capsys.readouterr()
     assert "✅ Completed" in captured.out
-    assert "⏭️ Pending" in captured.out
+    assert "❓ Unknown" in captured.out

--- a/tests/test_quest_state.py
+++ b/tests/test_quest_state.py
@@ -23,13 +23,10 @@ def test_read_saved_quest_log(tmp_path, monkeypatch):
 def test_get_step_status(tmp_path, monkeypatch):
     log_file = tmp_path / "logs" / "quest_log.txt"
     log_file.parent.mkdir()
-    log_file.write_text("1\n")
+    log_file.write_text("Step 1 completed\nStep 2 failed\nStep 3 in progress\n")
     monkeypatch.chdir(tmp_path)
 
-    step_completed = {"id": "1"}
-    step_active = {"id": "2", "active": True}
-    step_pending = {"id": "3"}
-
-    assert qs.get_step_status(step_completed) == "✅ Completed"
-    assert qs.get_step_status(step_active) == "🕒 Active"
-    assert qs.get_step_status(step_pending) == "⏭️ Pending"
+    assert qs.get_step_status("1") == "✅ Completed"
+    assert qs.get_step_status("2") == "❌ Failed"
+    assert qs.get_step_status("3") == "⏳ In Progress"
+    assert qs.get_step_status("4") == "❓ Unknown"


### PR DESCRIPTION
## Summary
- manage quest log file via `QUEST_LOG_PATH`
- expand `get_step_status` to handle completion, failure, progress or unknown
- adjust legacy dashboard to use the new API
- update tests for revised quest status logic

## Testing
- `pytest tests/test_quest_state.py tests/test_legacy_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6866b29376108331a22e1cc3abb67880