### PR TITLE
Refactor legacy dashboard progress

### DIFF
--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -5,20 +5,18 @@ from __future__ import annotations
 from rich.console import Console
 from rich.table import Table
 
-from .legacy_tracker import load_legacy_steps
 from .quest_state import get_step_status
 
 
-def display_legacy_progress() -> None:
-    """Print a table of legacy quest steps and completion status."""
-    steps = load_legacy_steps()
+def display_legacy_progress(quest_steps: list) -> None:
+    """Print a table of ``quest_steps`` and completion status."""
 
-    table = Table(title="Legacy Quest Progress")
-    table.add_column("ID", style="bold", no_wrap=True)
-    table.add_column("Title")
+    table = Table(title="Legacy Quest Progress", show_lines=True)
+    table.add_column("Step ID", style="bold", no_wrap=True)
+    table.add_column("Step Name")
     table.add_column("Status", justify="center")
 
-    for step in steps:
+    for step in quest_steps:
         step_id = str(step.get("id"))
         title = step.get("title") or step.get("description", "")
         status = get_step_status(step_id)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import argparse
 
 from core.legacy_loop import run_full_legacy_quest
 from core.legacy_dashboard import display_legacy_progress
+from core.legacy_tracker import load_legacy_steps
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -30,7 +31,8 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
 
     if args.show_legacy_status:
-        display_legacy_progress()
+        steps = load_legacy_steps()
+        display_legacy_progress(steps)
 
     if args.legacy or not (args.legacy or args.show_legacy_status):
         run_full_legacy_quest()

--- a/tests/test_legacy_dashboard.py
+++ b/tests/test_legacy_dashboard.py
@@ -3,16 +3,35 @@ import core.quest_state as qs
 
 
 def test_display_legacy_progress(monkeypatch, capsys):
-    monkeypatch.setattr(
-        legacy_dashboard,
-        "load_legacy_steps",
-        lambda: [
-            {"id": 1, "title": "First"},
-            {"id": 2, "title": "Second"},
-        ],
-    )
+    steps = [
+        {"id": 1, "title": "First"},
+        {"id": 2, "title": "Second"},
+    ]
     monkeypatch.setattr(qs, "read_saved_quest_log", lambda: ["quest 1 completed"])
-    legacy_dashboard.display_legacy_progress()
+    legacy_dashboard.display_legacy_progress(steps)
     captured = capsys.readouterr()
     assert "✅ Completed" in captured.out
     assert "❓ Unknown" in captured.out
+
+
+def test_enriched_status_output(monkeypatch, capsys):
+    steps = [
+        {"id": 1, "title": "First"},
+        {"id": 2, "title": "Second"},
+        {"id": 3, "title": "Third"},
+    ]
+
+    monkeypatch.setattr(
+        qs,
+        "read_saved_quest_log",
+        lambda: [
+            "step 1 completed",
+            "step 2 failed",
+            "step 3 in progress",
+        ],
+    )
+    legacy_dashboard.display_legacy_progress(steps)
+    captured = capsys.readouterr()
+    assert "✅ Completed" in captured.out
+    assert "❌ Failed" in captured.out
+    assert "⏳ In Progress" in captured.out

--- a/tests/test_main_legacy_cli.py
+++ b/tests/test_main_legacy_cli.py
@@ -22,7 +22,7 @@ def test_main_runs_legacy_by_default(monkeypatch):
     legacy_main_mod = importlib.reload(legacy_main)
     called = {}
     monkeypatch.setattr(legacy_main_mod, "run_full_legacy_quest", lambda: called.setdefault("legacy", True))
-    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda: called.setdefault("status", True))
+    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda steps: called.setdefault("status", True))
     legacy_main_mod.main([])
     assert called.get("legacy") is True
     assert "status" not in called
@@ -31,8 +31,9 @@ def test_main_runs_legacy_by_default(monkeypatch):
 def test_main_show_status_only(monkeypatch):
     legacy_main_mod = importlib.reload(legacy_main)
     called = []
-    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda: called.append("status"))
+    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda steps: called.append("status"))
     monkeypatch.setattr(legacy_main_mod, "run_full_legacy_quest", lambda: called.append("legacy"))
+    monkeypatch.setattr(legacy_main_mod, "load_legacy_steps", lambda: [1])
     legacy_main_mod.main(["--show-legacy-status"])
     assert called == ["status"]
 
@@ -41,7 +42,7 @@ def test_main_legacy_flag(monkeypatch):
     legacy_main_mod = importlib.reload(legacy_main)
     called = {}
     monkeypatch.setattr(legacy_main_mod, "run_full_legacy_quest", lambda: called.setdefault("legacy", True))
-    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda: called.setdefault("status", True))
+    monkeypatch.setattr(legacy_main_mod, "display_legacy_progress", lambda steps: called.setdefault("status", True))
     legacy_main_mod.main(["--legacy"])
     assert called.get("legacy") is True
     assert "status" not in called


### PR DESCRIPTION
## Summary
- refactor `display_legacy_progress` to accept quest steps
- render table with step id, name, and status using `rich` with show lines
- update CLI to pass loaded legacy steps
- adjust legacy dashboard and main CLI tests
- add test for enriched status output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68670c39f2f08331b0404fb742417583