### PR TITLE
Add theme park progress modules

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -40,6 +40,12 @@ from .quest_state import (
     read_saved_quest_log,
     get_step_status,
 )
+from .themepark_tracker import (
+    read_themepark_log,
+    is_themepark_quest_active,
+    get_themepark_status,
+)
+from .themepark_dashboard import display_themepark_progress
 
 __all__ = [
     "preprocess_image",
@@ -80,4 +86,8 @@ __all__ = [
     "extract_quest_log_from_screenshot",
     "read_saved_quest_log",
     "get_step_status",
+    "read_themepark_log",
+    "is_themepark_quest_active",
+    "get_themepark_status",
+    "display_themepark_progress",
 ]

--- a/core/themepark_dashboard.py
+++ b/core/themepark_dashboard.py
@@ -1,0 +1,22 @@
+"""Displays a progress table for Theme Park quests using the rich library."""
+
+from __future__ import annotations
+
+from rich.table import Table
+from rich.console import Console
+
+from .themepark_tracker import get_themepark_status
+
+
+def display_themepark_progress(quests: list[str]) -> None:
+    """Print a table of theme park ``quests`` and their status."""
+    table = Table(title="Theme Park Quest Progress")
+    table.add_column("Quest", style="bold")
+    table.add_column("Status", style="cyan")
+
+    for quest in quests:
+        status = get_themepark_status(quest)
+        table.add_row(quest, status)
+
+    console = Console()
+    console.print(table)

--- a/core/themepark_tracker.py
+++ b/core/themepark_tracker.py
@@ -1,0 +1,36 @@
+"""Module for tracking the status of Theme Park quests based on log file data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+THEMEPARK_LOG_PATH = Path("logs/themepark_log.txt")
+
+
+def read_themepark_log() -> list[str]:
+    """Return cleaned lines from :data:`THEMEPARK_LOG_PATH` if it exists."""
+    if not THEMEPARK_LOG_PATH.exists():
+        return []
+    with THEMEPARK_LOG_PATH.open("r", encoding="utf-8") as fh:
+        return [line.strip() for line in fh.readlines()]
+
+
+def is_themepark_quest_active(quest_name: str) -> bool:
+    """Return ``True`` if ``quest_name`` appears in the theme park log."""
+    log = read_themepark_log()
+    return any(quest_name.lower() in line.lower() for line in log)
+
+
+def get_themepark_status(quest_name: str) -> str:
+    """Return a status string for ``quest_name`` from the theme park log."""
+    log = read_themepark_log()
+    for line in log:
+        if quest_name.lower() in line.lower():
+            lowered = line.lower()
+            if "completed" in lowered:
+                return "Completed"
+            if "in progress" in lowered:
+                return "In Progress"
+            if "failed" in lowered:
+                return "Failed"
+    return "Unknown"


### PR DESCRIPTION
## Summary
- add a theme park quest tracker
- show theme park quest progress using Rich tables
- expose new tracker & dashboard utilities in `core.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_b_68672288e464833189895867d76a54f8