### PR TITLE
Add theme park status CLI flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,14 @@ import argparse
 from core.legacy_loop import run_full_legacy_quest
 from core.legacy_dashboard import display_legacy_progress
 from core.legacy_tracker import load_legacy_steps
+from core.themepark_dashboard import display_themepark_progress
+
+# Names of theme park quest lines to show in status output
+THEMEPARK_CHAINS = [
+    "Jabba",
+    "Rebel",
+    "Imperial",
+]
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -23,6 +31,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Display current legacy quest progress",
     )
+    parser.add_argument(
+        "--show-themepark-status",
+        dest="show_themepark_status",
+        action="store_true",
+        help="Display current theme park quest progress",
+    )
     return parser.parse_args(argv)
 
 
@@ -34,7 +48,10 @@ def main(argv: list[str] | None = None) -> None:
         steps = load_legacy_steps()
         display_legacy_progress(steps)
 
-    if args.legacy or not (args.legacy or args.show_legacy_status):
+    if args.show_themepark_status:
+        display_themepark_progress(THEMEPARK_CHAINS)
+
+    if args.legacy or not (args.legacy or args.show_legacy_status or args.show_themepark_status):
         run_full_legacy_quest()
 
 

--- a/tests/test_main_legacy_cli.py
+++ b/tests/test_main_legacy_cli.py
@@ -18,6 +18,13 @@ def test_parse_args_show_status(monkeypatch):
     assert args.legacy is False
 
 
+def test_parse_args_show_themepark_status(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--show-themepark-status"])
+    args = legacy_main.parse_args()
+    assert args.show_themepark_status is True
+    assert args.legacy is False
+
+
 def test_main_runs_legacy_by_default(monkeypatch):
     legacy_main_mod = importlib.reload(legacy_main)
     called = {}
@@ -46,4 +53,19 @@ def test_main_legacy_flag(monkeypatch):
     legacy_main_mod.main(["--legacy"])
     assert called.get("legacy") is True
     assert "status" not in called
+
+
+def test_main_themepark_status(monkeypatch):
+    legacy_main_mod = importlib.reload(legacy_main)
+    called = []
+    monkeypatch.setattr(
+        legacy_main_mod,
+        "display_themepark_progress",
+        lambda quests: called.append("themepark"),
+    )
+    monkeypatch.setattr(
+        legacy_main_mod, "run_full_legacy_quest", lambda: called.append("legacy")
+    )
+    legacy_main_mod.main(["--show-themepark-status"])
+    assert called == ["themepark"]
 


### PR DESCRIPTION
## Summary
- add `--show-themepark-status` flag to the legacy CLI
- call `display_themepark_progress` when used
- test new flag behaviour in `test_main_legacy_cli.py`

## Testing
- `pytest tests/test_main_legacy_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686785253fa48331920351c4cb08f026