### PR TITLE
Document themepark status CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The original MS11-Core implementation has been archived under `archive/ms11-core
 
 ## Features
 - 🧭 Legacy Quest Dashboard: View progress with `--show-legacy-status`
+- 🎡 Theme Park Dashboard: View progress with `--show-themepark-status`
 - ✅ Smart Retry Logic: automatically retries failed quest steps up to 3 times, writing details to `logs/retry_log.txt`
 - 📊 Quest Step Enrichment (Completed / Failed / In Progress / Unknown)
 
@@ -465,6 +466,7 @@ Launch the legacy quest loop directly or just display progress with:
 ```bash
 python main.py --legacy
 python main.py --show-legacy-status
+python main.py --show-themepark-status
 ```
 
 ## Quest Selection CLI


### PR DESCRIPTION
## Summary
- mention `--show-themepark-status` in the Features list
- show how to call it in the legacy quest example

## Testing
- `pytest tests/test_main_legacy_cli.py::test_parse_args_show_themepark_status -q`

------
https://chatgpt.com/codex/tasks/task_b_68678a40453083319b049cbcaffdfec2