### PR TITLE
Add unified dashboard feature

### DIFF
--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -8,8 +8,8 @@ from rich.table import Table
 from .quest_state import get_step_status
 
 
-def display_legacy_progress(quest_steps: list) -> None:
-    """Print a table of ``quest_steps`` and completion status."""
+def build_legacy_progress_table(quest_steps: list) -> Table:
+    """Return a ``rich`` table showing ``quest_steps`` progress."""
 
     table = Table(title="Legacy Quest Progress", show_lines=True)
     table.add_column("Step ID", style="bold", no_wrap=True)
@@ -22,7 +22,13 @@ def display_legacy_progress(quest_steps: list) -> None:
         status = get_step_status(step_id)
         table.add_row(step_id, title, status)
 
-    Console().print(table)
+    return table
 
 
-__all__ = ["display_legacy_progress"]
+def display_legacy_progress(quest_steps: list) -> None:
+    """Print a table of ``quest_steps`` and completion status."""
+
+    Console().print(build_legacy_progress_table(quest_steps))
+
+
+__all__ = ["build_legacy_progress_table", "display_legacy_progress"]

--- a/core/themepark_dashboard.py
+++ b/core/themepark_dashboard.py
@@ -8,8 +8,9 @@ from rich.console import Console
 from .themepark_tracker import get_themepark_status
 
 
-def display_themepark_progress(quests: list[str]) -> None:
-    """Print a table of theme park ``quests`` and their status."""
+def build_themepark_progress_table(quests: list[str]) -> Table:
+    """Return a table summarizing theme park quest ``quests`` progress."""
+
     table = Table(title="Theme Park Quest Progress")
     table.add_column("Quest", style="bold")
     table.add_column("Status", style="cyan")
@@ -18,5 +19,13 @@ def display_themepark_progress(quests: list[str]) -> None:
         status = get_themepark_status(quest)
         table.add_row(quest, status)
 
-    console = Console()
-    console.print(table)
+    return table
+
+
+def display_themepark_progress(quests: list[str]) -> None:
+    """Print a table of theme park ``quests`` and their status."""
+
+    Console().print(build_themepark_progress_table(quests))
+
+
+__all__ = ["build_themepark_progress_table", "display_themepark_progress"]

--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -1,0 +1,29 @@
+"""Display legacy and theme park quest progress together using ``rich``."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.layout import Layout
+
+from .legacy_tracker import load_legacy_steps
+from .legacy_dashboard import build_legacy_progress_table
+from .themepark_dashboard import build_themepark_progress_table
+
+
+def show_unified_dashboard(themepark_quests: list[str]) -> None:
+    """Print a dashboard with legacy and theme park progress."""
+
+    steps = load_legacy_steps()
+    legacy_table = build_legacy_progress_table(steps)
+    themepark_table = build_themepark_progress_table(themepark_quests)
+
+    layout = Layout()
+    layout.split_column(
+        Layout(legacy_table, name="legacy"),
+        Layout(themepark_table, name="themepark"),
+    )
+
+    Console().print(layout)
+
+
+__all__ = ["show_unified_dashboard"]

--- a/tests/test_unified_dashboard.py
+++ b/tests/test_unified_dashboard.py
@@ -1,0 +1,15 @@
+import core.unified_dashboard as unified
+import core.legacy_tracker as legacy_tracker
+import core.quest_state as qs
+import core.themepark_tracker as tp
+
+
+def test_show_unified_dashboard(monkeypatch, capsys):
+    monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
+    monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: "Complete")
+    monkeypatch.setattr(tp, "get_themepark_status", lambda q: "Done")
+
+    unified.show_unified_dashboard(["Jabba"])
+    out = capsys.readouterr().out
+    assert "Legacy Quest Progress" in out
+    assert "Theme Park Quest" in out


### PR DESCRIPTION
## Summary
- add `build_legacy_progress_table` helper and refactor dashboard
- add `build_themepark_progress_table` helper
- implement `show_unified_dashboard` using rich `Layout`
- test unified dashboard output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686793c1a3e083319076b9ae0d8c60e1