### PR TITLE
Add unified dashboard loaders

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -31,7 +31,7 @@ from src.execution import quest_engine
 from .quest_engine import execute_quest_step, execute_with_retry
 from .legacy_tracker import load_legacy_steps, read_quest_log
 from .legacy_loop import run_full_legacy_quest
-from .legacy_dashboard import display_legacy_progress
+from .legacy_dashboard import display_legacy_progress, render_legacy_table
 from .quest_state import (
     parse_quest_log,
     is_step_completed,
@@ -44,8 +44,9 @@ from .themepark_tracker import (
     read_themepark_log,
     is_themepark_quest_active,
     get_themepark_status,
+    load_themepark_chains,
 )
-from .themepark_dashboard import display_themepark_progress
+from .themepark_dashboard import display_themepark_progress, render_themepark_table
 
 __all__ = [
     "preprocess_image",
@@ -80,6 +81,7 @@ __all__ = [
     "read_quest_log",
     "run_full_legacy_quest",
     "display_legacy_progress",
+    "render_legacy_table",
     "parse_quest_log",
     "is_step_completed",
     "scan_log_file_for_step",
@@ -89,5 +91,7 @@ __all__ = [
     "read_themepark_log",
     "is_themepark_quest_active",
     "get_themepark_status",
+    "load_themepark_chains",
     "display_themepark_progress",
+    "render_themepark_table",
 ]

--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from rich.console import Console
 from rich.table import Table
 
+from .legacy_tracker import load_legacy_steps
+
 from .quest_state import get_step_status
 
 
@@ -25,10 +27,18 @@ def build_legacy_progress_table(quest_steps: list) -> Table:
     return table
 
 
+def render_legacy_table(quest_steps: list | None = None) -> Table:
+    """Return a table for ``quest_steps`` or all legacy steps when ``None``."""
+
+    if quest_steps is None:
+        quest_steps = load_legacy_steps()
+    return build_legacy_progress_table(quest_steps)
+
+
 def display_legacy_progress(quest_steps: list) -> None:
     """Print a table of ``quest_steps`` and completion status."""
 
     Console().print(build_legacy_progress_table(quest_steps))
 
 
-__all__ = ["build_legacy_progress_table", "display_legacy_progress"]
+__all__ = ["build_legacy_progress_table", "display_legacy_progress", "render_legacy_table"]

--- a/core/themepark_dashboard.py
+++ b/core/themepark_dashboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.table import Table
 from rich.console import Console
 
-from .themepark_tracker import get_themepark_status
+from .themepark_tracker import get_themepark_status, load_themepark_chains
 
 
 def build_themepark_progress_table(quests: list[str]) -> Table:
@@ -22,10 +22,22 @@ def build_themepark_progress_table(quests: list[str]) -> Table:
     return table
 
 
+def render_themepark_table(quests: list[str] | None = None) -> Table:
+    """Return a ``rich`` table for theme park ``quests`` or default chains."""
+
+    if quests is None:
+        quests = load_themepark_chains()
+    return build_themepark_progress_table(quests)
+
+
 def display_themepark_progress(quests: list[str]) -> None:
     """Print a table of theme park ``quests`` and their status."""
 
     Console().print(build_themepark_progress_table(quests))
 
 
-__all__ = ["build_themepark_progress_table", "display_themepark_progress"]
+__all__ = [
+    "build_themepark_progress_table",
+    "display_themepark_progress",
+    "render_themepark_table",
+]

--- a/core/themepark_tracker.py
+++ b/core/themepark_tracker.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import List
 
 THEMEPARK_LOG_PATH = Path("logs/themepark_log.txt")
+
+# Names of supported Theme Park quest lines
+THEMEPARK_CHAINS = ["Jabba", "Rebel", "Imperial"]
+
+
+def load_themepark_chains() -> List[str]:
+    """Return a list of available theme park quest lines."""
+    return list(THEMEPARK_CHAINS)
 
 
 def read_themepark_log() -> list[str]:

--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -6,16 +6,20 @@ from rich.console import Console
 from rich.layout import Layout
 
 from .legacy_tracker import load_legacy_steps
-from .legacy_dashboard import build_legacy_progress_table
-from .themepark_dashboard import build_themepark_progress_table
+from .legacy_dashboard import render_legacy_table
+from .themepark_tracker import load_themepark_chains
+from .themepark_dashboard import render_themepark_table
 
 
-def show_unified_dashboard(themepark_quests: list[str]) -> None:
+def show_unified_dashboard(themepark_quests: list[str] | None = None) -> None:
     """Print a dashboard with legacy and theme park progress."""
 
     steps = load_legacy_steps()
-    legacy_table = build_legacy_progress_table(steps)
-    themepark_table = build_themepark_progress_table(themepark_quests)
+    if themepark_quests is None:
+        themepark_quests = load_themepark_chains()
+
+    legacy_table = render_legacy_table(steps)
+    themepark_table = render_themepark_table(themepark_quests)
 
     layout = Layout()
     layout.split_column(

--- a/main.py
+++ b/main.py
@@ -8,13 +8,7 @@ from core.legacy_loop import run_full_legacy_quest
 from core.legacy_dashboard import display_legacy_progress
 from core.legacy_tracker import load_legacy_steps
 from core.themepark_dashboard import display_themepark_progress
-
-# Names of theme park quest lines to show in status output
-THEMEPARK_CHAINS = [
-    "Jabba",
-    "Rebel",
-    "Imperial",
-]
+from core.themepark_tracker import load_themepark_chains
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -49,7 +43,7 @@ def main(argv: list[str] | None = None) -> None:
         display_legacy_progress(steps)
 
     if args.show_themepark_status:
-        display_themepark_progress(THEMEPARK_CHAINS)
+        display_themepark_progress(load_themepark_chains())
 
     if args.legacy or not (args.legacy or args.show_legacy_status or args.show_themepark_status):
         run_full_legacy_quest()


### PR DESCRIPTION
## Summary
- extend themepark tracker with `load_themepark_chains`
- render legacy and themepark tables on demand
- update unified dashboard to call load functions
- load theme park chains in CLI

## Testing
- `pip install rich`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686796fc84d883319460e6b70b15254e