### PR TITLE
Add unified dashboard CLI

### DIFF
--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -11,8 +11,12 @@ from .themepark_tracker import load_themepark_chains
 from .themepark_dashboard import render_themepark_table
 
 
-def show_unified_dashboard(themepark_quests: list[str] | None = None) -> None:
-    """Print a dashboard with legacy and theme park progress."""
+def show_unified_dashboard(
+    themepark_quests: list[str] | None = None,
+    *,
+    mode: str = "all",
+) -> None:
+    """Print a dashboard with quest progress based on ``mode``."""
 
     steps = load_legacy_steps()
     if themepark_quests is None:
@@ -20,6 +24,13 @@ def show_unified_dashboard(themepark_quests: list[str] | None = None) -> None:
 
     legacy_table = render_legacy_table(steps)
     themepark_table = render_themepark_table(themepark_quests)
+
+    if mode == "legacy":
+        Console().print(legacy_table)
+        return
+    if mode == "themepark":
+        Console().print(themepark_table)
+        return
 
     layout = Layout()
     layout.split_column(

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from core.legacy_dashboard import display_legacy_progress
 from core.legacy_tracker import load_legacy_steps
 from core.themepark_dashboard import display_themepark_progress
 from core.themepark_tracker import load_themepark_chains
+from core.unified_dashboard import show_unified_dashboard
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -31,6 +32,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Display current theme park quest progress",
     )
+    parser.add_argument(
+        "--show-dashboard",
+        dest="show_dashboard",
+        action="store_true",
+        help="Display a unified quest progress dashboard",
+    )
+    parser.add_argument(
+        "--dashboard-mode",
+        choices=["legacy", "themepark", "all"],
+        default="all",
+        help="Select sections to display in the dashboard",
+    )
     return parser.parse_args(argv)
 
 
@@ -44,6 +57,10 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.show_themepark_status:
         display_themepark_progress(load_themepark_chains())
+
+    if args.show_dashboard:
+        show_unified_dashboard(mode=args.dashboard_mode)
+        return
 
     if args.legacy or not (args.legacy or args.show_legacy_status or args.show_themepark_status):
         run_full_legacy_quest()

--- a/tests/test_main_legacy_cli.py
+++ b/tests/test_main_legacy_cli.py
@@ -69,3 +69,32 @@ def test_main_themepark_status(monkeypatch):
     legacy_main_mod.main(["--show-themepark-status"])
     assert called == ["themepark"]
 
+
+def test_parse_args_show_dashboard(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--show-dashboard"])
+    args = legacy_main.parse_args()
+    assert args.show_dashboard is True
+    assert args.dashboard_mode == "all"
+
+
+def test_parse_args_dashboard_mode(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--dashboard-mode", "legacy"])
+    args = legacy_main.parse_args()
+    assert args.dashboard_mode == "legacy"
+    assert args.show_dashboard is False
+
+
+def test_main_show_dashboard(monkeypatch):
+    legacy_main_mod = importlib.reload(legacy_main)
+    called = {}
+    monkeypatch.setattr(
+        legacy_main_mod,
+        "show_unified_dashboard",
+        lambda *, mode="all": called.setdefault("dashboard", mode),
+    )
+    monkeypatch.setattr(
+        legacy_main_mod, "run_full_legacy_quest", lambda: called.setdefault("legacy", True)
+    )
+    legacy_main_mod.main(["--show-dashboard", "--dashboard-mode", "legacy"])
+    assert called == {"dashboard": "legacy"}
+


### PR DESCRIPTION
## Summary
- add `--show-dashboard` and `--dashboard-mode` options to `main.py`
- invoke `show_unified_dashboard` based on the CLI options
- extend `show_unified_dashboard` to support mode selection
- test new options and dashboard invocation

## Testing
- `pytest -k main_legacy_cli -q`
- `pytest tests/test_unified_dashboard.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868120a954083319544913f26c14018