### PR TITLE
Add tests for unified dashboard modes

### DIFF
--- a/tests/test_unified_dashboard.py
+++ b/tests/test_unified_dashboard.py
@@ -1,3 +1,5 @@
+import pytest
+
 import core.unified_dashboard as unified
 import core.legacy_tracker as legacy_tracker
 import core.quest_state as qs
@@ -13,3 +15,15 @@ def test_show_unified_dashboard(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Legacy Quest Progress" in out
     assert "Theme Park Quest" in out
+
+
+@pytest.mark.parametrize("mode", ["legacy", "themepark", "all"])
+def test_show_unified_dashboard_modes(monkeypatch, mode, capsys):
+    monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
+    monkeypatch.setattr(tp, "load_themepark_chains", lambda: ["Jabba"])
+    monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: "Complete")
+    monkeypatch.setattr(tp, "get_themepark_status", lambda q: "Done")
+
+    unified.show_unified_dashboard(mode=mode)
+    # Ensure some output was produced for sanity
+    assert capsys.readouterr().out


### PR DESCRIPTION
## Summary
- ensure `show_unified_dashboard` works for each dashboard mode
- mock loaders to avoid reading the real data files

## Testing
- `pytest tests/test_unified_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68681c7503d08331a42682ba5a1a9f2b