### PR TITLE
Introduce quest status constants

### DIFF
--- a/core/quest_state.py
+++ b/core/quest_state.py
@@ -8,6 +8,12 @@ from typing import List, Optional
 # Default path for the saved quest log
 QUEST_LOG_PATH = "logs/quest_log.txt"
 
+# Standardized status constants
+STATUS_COMPLETED = "✅ Completed"
+STATUS_FAILED = "❌ Failed"
+STATUS_IN_PROGRESS = "⏳ In Progress"
+STATUS_UNKNOWN = "❓ Unknown"
+
 
 def parse_quest_log(log_text: str) -> List[str]:
     """Return cleaned lines from a quest log ``log_text``."""
@@ -62,12 +68,12 @@ def get_step_status(step_id: str, log_lines: Optional[List[str]] = None) -> str:
         lowered = line.lower()
         if step_id in lowered:
             if "failed" in lowered:
-                return "❌ Failed"
+                return STATUS_FAILED
             if "complete" in lowered:
-                return "✅ Completed"
+                return STATUS_COMPLETED
             if "progress" in lowered or "started" in lowered or "in progress" in lowered:
-                return "⏳ In Progress"
-    return "❓ Unknown"
+                return STATUS_IN_PROGRESS
+    return STATUS_UNKNOWN
 
 
 __all__ = [
@@ -77,4 +83,8 @@ __all__ = [
     "extract_quest_log_from_screenshot",
     "read_saved_quest_log",
     "get_step_status",
+    "STATUS_COMPLETED",
+    "STATUS_FAILED",
+    "STATUS_IN_PROGRESS",
+    "STATUS_UNKNOWN",
 ]

--- a/core/themepark_tracker.py
+++ b/core/themepark_tracker.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 
+from .quest_state import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_IN_PROGRESS,
+    STATUS_UNKNOWN,
+)
+
 THEMEPARK_LOG_PATH = Path("logs/themepark_log.txt")
 
 # Names of supported Theme Park quest lines
@@ -38,9 +45,9 @@ def get_themepark_status(quest_name: str) -> str:
         if quest_name.lower() in line.lower():
             lowered = line.lower()
             if "completed" in lowered:
-                return "Completed"
+                return STATUS_COMPLETED
             if "in progress" in lowered:
-                return "In Progress"
+                return STATUS_IN_PROGRESS
             if "failed" in lowered:
-                return "Failed"
-    return "Unknown"
+                return STATUS_FAILED
+    return STATUS_UNKNOWN

--- a/tests/test_quest_state.py
+++ b/tests/test_quest_state.py
@@ -26,7 +26,7 @@ def test_get_step_status(tmp_path, monkeypatch):
     log_file.write_text("Step 1 completed\nStep 2 failed\nStep 3 in progress\n")
     monkeypatch.chdir(tmp_path)
 
-    assert qs.get_step_status("1") == "✅ Completed"
-    assert qs.get_step_status("2") == "❌ Failed"
-    assert qs.get_step_status("3") == "⏳ In Progress"
-    assert qs.get_step_status("4") == "❓ Unknown"
+    assert qs.get_step_status("1") == qs.STATUS_COMPLETED
+    assert qs.get_step_status("2") == qs.STATUS_FAILED
+    assert qs.get_step_status("3") == qs.STATUS_IN_PROGRESS
+    assert qs.get_step_status("4") == qs.STATUS_UNKNOWN

--- a/tests/test_themepark_tracker.py
+++ b/tests/test_themepark_tracker.py
@@ -20,10 +20,10 @@ def test_get_themepark_status(monkeypatch):
     ]
     monkeypatch.setattr(themepark_tracker, "read_themepark_log", lambda: logs)
 
-    assert themepark_tracker.get_themepark_status("Imperial Museum") == "Completed"
-    assert themepark_tracker.get_themepark_status("Rebel Adventure") == "In Progress"
-    assert themepark_tracker.get_themepark_status("Science Quest") == "Failed"
-    assert themepark_tracker.get_themepark_status("Unknown Quest") == "Unknown"
+    assert themepark_tracker.get_themepark_status("Imperial Museum") == themepark_tracker.STATUS_COMPLETED
+    assert themepark_tracker.get_themepark_status("Rebel Adventure") == themepark_tracker.STATUS_IN_PROGRESS
+    assert themepark_tracker.get_themepark_status("Science Quest") == themepark_tracker.STATUS_FAILED
+    assert themepark_tracker.get_themepark_status("Unknown Quest") == themepark_tracker.STATUS_UNKNOWN
 
 
 def test_is_themepark_quest_active(monkeypatch):

--- a/tests/test_unified_dashboard.py
+++ b/tests/test_unified_dashboard.py
@@ -8,8 +8,8 @@ import core.themepark_tracker as tp
 
 def test_show_unified_dashboard(monkeypatch, capsys):
     monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
-    monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: "Complete")
-    monkeypatch.setattr(tp, "get_themepark_status", lambda q: "Done")
+    monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: qs.STATUS_COMPLETED)
+    monkeypatch.setattr(tp, "get_themepark_status", lambda q: qs.STATUS_COMPLETED)
 
     unified.show_unified_dashboard(["Jabba"])
     out = capsys.readouterr().out
@@ -21,8 +21,8 @@ def test_show_unified_dashboard(monkeypatch, capsys):
 def test_show_unified_dashboard_modes(monkeypatch, mode, capsys):
     monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
     monkeypatch.setattr(tp, "load_themepark_chains", lambda: ["Jabba"])
-    monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: "Complete")
-    monkeypatch.setattr(tp, "get_themepark_status", lambda q: "Done")
+    monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: qs.STATUS_COMPLETED)
+    monkeypatch.setattr(tp, "get_themepark_status", lambda q: qs.STATUS_COMPLETED)
 
     unified.show_unified_dashboard(mode=mode)
     # Ensure some output was produced for sanity


### PR DESCRIPTION
## Summary
- define new status constants in `core.quest_state`
- return these constants from `get_step_status`
- unify `themepark_tracker.get_themepark_status` to use the same constants
- update tests to reference the constants

## Testing
- `pip install rich`
- `pytest tests/test_quest_state.py tests/test_unified_dashboard.py tests/test_themepark_tracker.py tests/test_legacy_dashboard.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868d18384d88331907d710727f1b07b