### PR TITLE
Fix README test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,14 @@ This section walks through a fresh setup so you can try the project locally.
 
 6. **Run the tests**
 
-   The repository contains a small test suite powered by `pytest`. The
-   tests rely on packages such as `langchain` and `transformers`, so
-   make sure all dependencies are installed first:
+   The repository contains a small test suite powered by `pytest`. Some
+   tests depend on additional packages such as `langchain` and
+   `transformers`, so make sure all dependencies are installed first:
 
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements.txt -r requirements-test.txt
    pytest
-    # includes requests>=2.0, PyYAML, and pymongo>=3.0
+    # test requirements include requests>=2.0, PyYAML, and pymongo>=3.0
 
    # run a subset of the test suite
    pytest -k support_mode -q


### PR DESCRIPTION
## Summary
- update `pip install` example to include `requirements-test.txt`
- mention that some tests rely on extra packages

## Testing
- `pytest -k support_mode -q`
- `pytest -k rls_mode -q`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68697e2a33908331a798df88d349cfc8