### PR TITLE
Centralize status constants

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -47,6 +47,12 @@ from .themepark_tracker import (
     load_themepark_chains,
 )
 from .themepark_dashboard import display_themepark_progress, render_themepark_table
+from .constants import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_IN_PROGRESS,
+    STATUS_UNKNOWN,
+)
 
 __all__ = [
     "preprocess_image",
@@ -94,5 +100,9 @@ __all__ = [
     "load_themepark_chains",
     "display_themepark_progress",
     "render_themepark_table",
+    "STATUS_COMPLETED",
+    "STATUS_FAILED",
+    "STATUS_IN_PROGRESS",
+    "STATUS_UNKNOWN",
     "show_unified_dashboard",
 ]

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,0 +1,4 @@
+STATUS_COMPLETED = "✅ Completed"
+STATUS_FAILED = "❌ Failed"
+STATUS_IN_PROGRESS = "⏳ In Progress"
+STATUS_UNKNOWN = "❓ Unknown"

--- a/core/quest_state.py
+++ b/core/quest_state.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
+from .constants import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_IN_PROGRESS,
+    STATUS_UNKNOWN,
+)
+
 # Default path for the saved quest log
 QUEST_LOG_PATH = "logs/quest_log.txt"
 
-# Standardized status constants
-STATUS_COMPLETED = "✅ Completed"
-STATUS_FAILED = "❌ Failed"
-STATUS_IN_PROGRESS = "⏳ In Progress"
-STATUS_UNKNOWN = "❓ Unknown"
+# Standardized status constants are imported for re-export
 
 
 def parse_quest_log(log_text: str) -> List[str]:

--- a/core/themepark_tracker.py
+++ b/core/themepark_tracker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 
-from .quest_state import (
+from .constants import (
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_IN_PROGRESS,

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,9 @@
+import core
+
+
+def test_constants_values():
+    assert core.STATUS_COMPLETED == "✅ Completed"
+    assert core.STATUS_FAILED == "❌ Failed"
+    assert core.STATUS_IN_PROGRESS == "⏳ In Progress"
+    assert core.STATUS_UNKNOWN == "❓ Unknown"
+


### PR DESCRIPTION
## Summary
- add `core.constants` for quest status strings
- use the new constants in `core.quest_state` and `core.themepark_tracker`
- re-export the constants from `core.__init__`
- test constant values

## Testing
- `pip install -q -r requirements.txt -r requirements-test.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686a20f979c8833193f16666efbdd5e1