### PR TITLE
Update __all__ for constants

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -100,9 +100,15 @@ __all__ = [
     "load_themepark_chains",
     "display_themepark_progress",
     "render_themepark_table",
-    "STATUS_COMPLETED",
-    "STATUS_FAILED",
-    "STATUS_IN_PROGRESS",
-    "STATUS_UNKNOWN",
     "show_unified_dashboard",
 ]
+
+# Export status constants for ``from core import *`` usage
+__all__.extend(
+    [
+        "STATUS_COMPLETED",
+        "STATUS_FAILED",
+        "STATUS_IN_PROGRESS",
+        "STATUS_UNKNOWN",
+    ]
+)


### PR DESCRIPTION
## Summary
- keep status constants import
- export status constants via `__all__.extend`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686a80bca8708331bda03ebcda8bd0a6