### PR TITLE
Add docstring and __all__ to constants module

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -1,4 +1,13 @@
+"""Common status strings used throughout the project."""
+
 STATUS_COMPLETED = "✅ Completed"
 STATUS_FAILED = "❌ Failed"
 STATUS_IN_PROGRESS = "⏳ In Progress"
 STATUS_UNKNOWN = "❓ Unknown"
+
+__all__ = [
+    "STATUS_COMPLETED",
+    "STATUS_FAILED",
+    "STATUS_IN_PROGRESS",
+    "STATUS_UNKNOWN",
+]


### PR DESCRIPTION
## Summary
- document status constants in a module docstring
- export constants via `__all__`

## Testing
- `pip install rich`
- `pytest tests/test_constants.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686aab95d5848331bbc08d190f6d9a1f