### PR TITLE
Centralize rich stub

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -11,51 +11,6 @@ except Exception:
 try:
     import rich  # noqa: F401
 except Exception:
-    import sys
-    import types
+    from tests.rich_stub import register_rich_stub
 
-    _rich = types.ModuleType("rich")
-
-    class _Console:
-        def print(self, *args, **kwargs):
-            print(*args)
-
-    console = types.ModuleType("console")
-    console.Console = _Console
-    _rich.console = console
-
-    class _Table:
-        def __init__(self, *args, **kwargs):
-            self.rows = []
-
-        def add_column(self, *args, **kwargs):
-            pass
-
-        def add_row(self, *args, **kwargs):
-            self.rows.append(args)
-
-        def __str__(self) -> str:  # pragma: no cover - trivial
-            return "\n".join(" | ".join(str(c) for c in r) for r in self.rows)
-
-    table = types.ModuleType("table")
-    table.Table = _Table
-    _rich.table = table
-
-    class _Layout:
-        def __init__(self, *args, **kwargs):
-            self.children = []
-
-        def split_column(self, *layouts):
-            self.children.extend(layouts)
-
-        def __str__(self) -> str:  # pragma: no cover - trivial
-            return "\n".join(str(c) for c in self.children)
-
-    layout = types.ModuleType("layout")
-    layout.Layout = _Layout
-    _rich.layout = layout
-
-    sys.modules.setdefault("rich", _rich)
-    sys.modules.setdefault("rich.console", console)
-    sys.modules.setdefault("rich.table", table)
-    sys.modules.setdefault("rich.layout", layout)
+    register_rich_stub()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,13 @@ import os
 import sys
 import types
 
+try:
+    import rich  # noqa: F401
+except Exception:
+    from .rich_stub import register_rich_stub
+
+    register_rich_stub()
+
 # Ensure project root is on the import path for tests
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:

--- a/tests/rich_stub.py
+++ b/tests/rich_stub.py
@@ -1,0 +1,51 @@
+import sys
+import types
+
+
+def register_rich_stub():
+    """Install minimal ``rich`` replacements for test environments."""
+    _rich = types.ModuleType("rich")
+
+    class _Console:
+        def print(self, *args, **kwargs):
+            print(*args)
+
+    console = types.ModuleType("console")
+    console.Console = _Console
+    _rich.console = console
+
+    class _Table:
+        def __init__(self, *args, **kwargs):
+            self.rows = []
+
+        def add_column(self, *args, **kwargs):
+            pass
+
+        def add_row(self, *args, **kwargs):
+            self.rows.append(args)
+
+        def __str__(self) -> str:  # pragma: no cover - trivial
+            return "\n".join(" | ".join(str(c) for c in r) for r in self.rows)
+
+    table = types.ModuleType("table")
+    table.Table = _Table
+    _rich.table = table
+
+    class _Layout:
+        def __init__(self, *args, **kwargs):
+            self.children = []
+
+        def split_column(self, *layouts):
+            self.children.extend(layouts)
+
+        def __str__(self) -> str:  # pragma: no cover - trivial
+            return "\n".join(str(c) for c in self.children)
+
+    layout = types.ModuleType("layout")
+    layout.Layout = _Layout
+    _rich.layout = layout
+
+    sys.modules.setdefault("rich", _rich)
+    sys.modules.setdefault("rich.console", console)
+    sys.modules.setdefault("rich.table", table)
+    sys.modules.setdefault("rich.layout", layout)


### PR DESCRIPTION
## Summary
- add `tests/rich_stub.py` helper module
- use the helper to provide a fallback `rich` implementation from `sitecustomize.py`
- register the stub in `tests/conftest.py`

## Testing
- `pytest tests/test_legacy_dashboard.py::test_enriched_status_output -q`
- `pytest tests/test_legacy_dashboard.py::test_display_legacy_progress -q`


------
https://chatgpt.com/codex/tasks/task_b_686ade260f2883318669032d94089c37