### PR TITLE
Add RETRY_LOG_PATH constant to quest executor

### DIFF
--- a/src/engine/quest_executor.py
+++ b/src/engine/quest_executor.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import os
+
 from src.execution.core import execute_step
 from .step_executor import run_validated_step
+
+# Path to the retry log used by :mod:`core.quest_engine`
+RETRY_LOG_PATH = os.path.join("logs", "retry_log.txt")
 
 
 def run_step_with_feedback(step: dict) -> bool:


### PR DESCRIPTION
## Summary
- define `RETRY_LOG_PATH` in `src/engine/quest_executor.py` so its value
  matches the constant used in `core.quest_engine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686afee703a48331b319052631d73f26