### PR TITLE
Fix table title handling in tests

### DIFF
--- a/tests/rich_stub.py
+++ b/tests/rich_stub.py
@@ -17,6 +17,7 @@ def register_rich_stub():
     class _Table:
         def __init__(self, *args, **kwargs):
             self.rows = []
+            self.title = kwargs.get("title", "")
 
         def add_column(self, *args, **kwargs):
             pass
@@ -25,7 +26,10 @@ def register_rich_stub():
             self.rows.append(args)
 
         def __str__(self) -> str:  # pragma: no cover - trivial
-            return "\n".join(" | ".join(str(c) for c in r) for r in self.rows)
+            table_str = "\n".join(" | ".join(str(c) for c in r) for r in self.rows)
+            if self.title:
+                return f"{self.title}\n{table_str}" if table_str else self.title
+            return table_str
 
     table = types.ModuleType("table")
     table.Table = _Table
@@ -33,7 +37,7 @@ def register_rich_stub():
 
     class _Layout:
         def __init__(self, *args, **kwargs):
-            self.children = []
+            self.children = list(args)
 
         def split_column(self, *layouts):
             self.children.extend(layouts)


### PR DESCRIPTION
## Summary
- improve the tests' rich stub Table so titles are stored and printed
- allow Layout to accept renderables so tables appear when converted to string

## Testing
- `pytest tests/test_unified_dashboard.py::test_show_unified_dashboard -q`

------
https://chatgpt.com/codex/tasks/task_b_686b234a89548331b4d0831e1a1414da