### PR TITLE
Expand rich stub and adjust dashboard tests

### DIFF
--- a/tests/rich_stub.py
+++ b/tests/rich_stub.py
@@ -7,29 +7,44 @@ def register_rich_stub():
     _rich = types.ModuleType("rich")
 
     class _Console:
+        """Very small stub of :class:`rich.console.Console`."""
+
+        printed: list[str] = []
+
         def print(self, *args, **kwargs):
-            print(*args)
+            rendered = " ".join(str(a) for a in args)
+            self.printed.append(rendered)
+            print(rendered)
 
     console = types.ModuleType("console")
     console.Console = _Console
     _rich.console = console
 
     class _Table:
+        """Minimal ``Table`` implementation for tests."""
+
         def __init__(self, *args, **kwargs):
             self.rows = []
+            self.columns = []
             self.title = kwargs.get("title", "")
 
-        def add_column(self, *args, **kwargs):
-            pass
+        def add_column(self, name, *args, **kwargs):
+            self.columns.append(name)
 
         def add_row(self, *args, **kwargs):
             self.rows.append(args)
 
         def __str__(self) -> str:  # pragma: no cover - trivial
-            table_str = "\n".join(" | ".join(str(c) for c in r) for r in self.rows)
+            rows = [" | ".join(str(c) for c in r) for r in self.rows]
+            header = " | ".join(self.columns)
+            parts = []
             if self.title:
-                return f"{self.title}\n{table_str}" if table_str else self.title
-            return table_str
+                parts.append(self.title)
+            if header:
+                parts.append(header)
+            if rows:
+                parts.append("\n".join(rows))
+            return "\n".join(parts)
 
     table = types.ModuleType("table")
     table.Table = _Table

--- a/tests/test_unified_dashboard.py
+++ b/tests/test_unified_dashboard.py
@@ -4,21 +4,24 @@ import core.unified_dashboard as unified
 import core.legacy_tracker as legacy_tracker
 import core.quest_state as qs
 import core.themepark_tracker as tp
+from rich.console import Console
 
 
-def test_show_unified_dashboard(monkeypatch, capsys):
+def test_show_unified_dashboard(monkeypatch):
+    Console.printed.clear()
     monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
     monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: qs.STATUS_COMPLETED)
     monkeypatch.setattr(tp, "get_themepark_status", lambda q: qs.STATUS_COMPLETED)
 
     unified.show_unified_dashboard(["Jabba"])
-    out = capsys.readouterr().out
+    out = "\n".join(Console.printed)
     assert "Legacy Quest Progress" in out
     assert "Theme Park Quest" in out
 
 
 @pytest.mark.parametrize("mode", ["legacy", "themepark", "all"])
-def test_show_unified_dashboard_modes(monkeypatch, mode, capsys):
+def test_show_unified_dashboard_modes(monkeypatch, mode):
+    Console.printed.clear()
     monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
     monkeypatch.setattr(tp, "load_themepark_chains", lambda: ["Jabba"])
     monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: qs.STATUS_COMPLETED)
@@ -26,4 +29,4 @@ def test_show_unified_dashboard_modes(monkeypatch, mode, capsys):
 
     unified.show_unified_dashboard(mode=mode)
     # Ensure some output was produced for sanity
-    assert capsys.readouterr().out
+    assert Console.printed

--- a/tests/test_unified_dashboard.py
+++ b/tests/test_unified_dashboard.py
@@ -7,21 +7,21 @@ import core.themepark_tracker as tp
 from rich.console import Console
 
 
-def test_show_unified_dashboard(monkeypatch):
-    Console.printed.clear()
+def test_show_unified_dashboard(monkeypatch, capsys):
+    Console.printed.clear() if hasattr(Console, "printed") else None
     monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
     monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: qs.STATUS_COMPLETED)
     monkeypatch.setattr(tp, "get_themepark_status", lambda q: qs.STATUS_COMPLETED)
 
     unified.show_unified_dashboard(["Jabba"])
-    out = "\n".join(Console.printed)
+    out = capsys.readouterr().out
     assert "Legacy Quest Progress" in out
     assert "Theme Park Quest" in out
 
 
 @pytest.mark.parametrize("mode", ["legacy", "themepark", "all"])
-def test_show_unified_dashboard_modes(monkeypatch, mode):
-    Console.printed.clear()
+def test_show_unified_dashboard_modes(monkeypatch, capsys, mode):
+    Console.printed.clear() if hasattr(Console, "printed") else None
     monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: [{"id": 1, "title": "First"}])
     monkeypatch.setattr(tp, "load_themepark_chains", lambda: ["Jabba"])
     monkeypatch.setattr(qs, "get_step_status", lambda step_id, log_lines=None: qs.STATUS_COMPLETED)
@@ -29,4 +29,4 @@ def test_show_unified_dashboard_modes(monkeypatch, mode):
 
     unified.show_unified_dashboard(mode=mode)
     # Ensure some output was produced for sanity
-    assert Console.printed
+    assert capsys.readouterr().out


### PR DESCRIPTION
## Summary
- extend rich stub with column tracking and captured console output
- include table title, columns, and rows when rendering
- update dashboard tests to read captured console output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b7128038083319186664ce18be527