### PR TITLE
Add __all__ assertions for constants

### DIFF
--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -23,6 +23,7 @@ from core.constants import (
     STATUS_FAILED,
     STATUS_IN_PROGRESS,
     STATUS_UNKNOWN,
+    __all__,
 )
 
 # Clean up our temporary stubs so other tests use the real package
@@ -42,4 +43,11 @@ def test_constants_values():
     assert STATUS_FAILED == "❌ Failed"
     assert STATUS_IN_PROGRESS == "⏳ In Progress"
     assert STATUS_UNKNOWN == "❓ Unknown"
+    for name in (
+        "STATUS_COMPLETED",
+        "STATUS_FAILED",
+        "STATUS_IN_PROGRESS",
+        "STATUS_UNKNOWN",
+    ):
+        assert name in __all__
 


### PR DESCRIPTION
## Summary
- verify the constants module's `__all__` exports

## Testing
- `pytest tests/test_constants.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b7521c928833187b3a1a127f2e764