### PR TITLE
Add optional legacy_steps to unified dashboard

### DIFF
--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -15,14 +15,16 @@ def show_unified_dashboard(
     themepark_quests: list[str] | None = None,
     *,
     mode: str = "all",
+    legacy_steps: list | None = None,
 ) -> None:
     """Print a dashboard with quest progress based on ``mode``."""
 
-    steps = load_legacy_steps()
+    if legacy_steps is None:
+        legacy_steps = load_legacy_steps()
     if themepark_quests is None:
         themepark_quests = load_themepark_chains()
 
-    legacy_table = render_legacy_table(steps)
+    legacy_table = render_legacy_table(legacy_steps)
     themepark_table = render_themepark_table(themepark_quests)
 
     if mode == "legacy":


### PR DESCRIPTION
## Summary
- support optional `legacy_steps` in `show_unified_dashboard`
- ensure tests cover using custom steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b76c94edc8331830f8ec279b80d48