### PR TITLE
Add STATUS_NOT_STARTED constant

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -51,6 +51,7 @@ from .constants import (
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_IN_PROGRESS,
+    STATUS_NOT_STARTED,
     STATUS_UNKNOWN,
 )
 
@@ -109,6 +110,7 @@ __all__.extend(
         "STATUS_COMPLETED",
         "STATUS_FAILED",
         "STATUS_IN_PROGRESS",
+        "STATUS_NOT_STARTED",
         "STATUS_UNKNOWN",
     ]
 )

--- a/core/constants.py
+++ b/core/constants.py
@@ -3,11 +3,13 @@
 STATUS_COMPLETED = "✅ Completed"
 STATUS_FAILED = "❌ Failed"
 STATUS_IN_PROGRESS = "⏳ In Progress"
+STATUS_NOT_STARTED = "📝 Not Started"
 STATUS_UNKNOWN = "❓ Unknown"
 
 __all__ = [
     "STATUS_COMPLETED",
     "STATUS_FAILED",
     "STATUS_IN_PROGRESS",
+    "STATUS_NOT_STARTED",
     "STATUS_UNKNOWN",
 ]

--- a/core/quest_state.py
+++ b/core/quest_state.py
@@ -9,6 +9,7 @@ from .constants import (
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_IN_PROGRESS,
+    STATUS_NOT_STARTED,
     STATUS_UNKNOWN,
 )
 
@@ -89,5 +90,6 @@ __all__ = [
     "STATUS_COMPLETED",
     "STATUS_FAILED",
     "STATUS_IN_PROGRESS",
+    "STATUS_NOT_STARTED",
     "STATUS_UNKNOWN",
 ]

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -22,6 +22,7 @@ from core.constants import (
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_IN_PROGRESS,
+    STATUS_NOT_STARTED,
     STATUS_UNKNOWN,
     __all__,
 )
@@ -42,11 +43,13 @@ def test_constants_values():
     assert STATUS_COMPLETED == "✅ Completed"
     assert STATUS_FAILED == "❌ Failed"
     assert STATUS_IN_PROGRESS == "⏳ In Progress"
+    assert STATUS_NOT_STARTED == "📝 Not Started"
     assert STATUS_UNKNOWN == "❓ Unknown"
     for name in (
         "STATUS_COMPLETED",
         "STATUS_FAILED",
         "STATUS_IN_PROGRESS",
+        "STATUS_NOT_STARTED",
         "STATUS_UNKNOWN",
     ):
         assert name in __all__


### PR DESCRIPTION
## Summary
- add STATUS_NOT_STARTED to common constants
- re-export new status constant from quest_state and core package
- check STATUS_NOT_STARTED in constants tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b7cd63f40833182c21190fc13b323