### PR TITLE
Validate mode in unified dashboard

### DIFF
--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -19,6 +19,12 @@ def show_unified_dashboard(
 ) -> None:
     """Print a dashboard with quest progress based on ``mode``."""
 
+    allowed_modes = {"legacy", "themepark", "all"}
+    if mode not in allowed_modes:
+        raise ValueError(
+            f"Invalid mode '{mode}'. Expected one of {', '.join(sorted(allowed_modes))}"
+        )
+
     if legacy_steps is None:
         legacy_steps = load_legacy_steps()
     if themepark_quests is None:

--- a/tests/test_unified_dashboard.py
+++ b/tests/test_unified_dashboard.py
@@ -49,3 +49,10 @@ def test_show_unified_dashboard_custom_steps(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Legacy Quest Progress" in out
     assert "Theme Park Quest" in out
+
+
+def test_show_unified_dashboard_invalid_mode():
+    """Invalid modes should raise a ValueError."""
+
+    with pytest.raises(ValueError):
+        unified.show_unified_dashboard(mode="bogus")


### PR DESCRIPTION
## Summary
- validate `mode` parameter in `show_unified_dashboard`
- test that invalid dashboard modes raise `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b7db686808331b75f0b0f32847589