### PR TITLE
Clean up unused imports with ruff

### DIFF
--- a/android_ms11/core/performance_tracker.py
+++ b/android_ms11/core/performance_tracker.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Dict, Any
 
 from src.utils.logger import log_performance_summary

--- a/archive/ms11-core/xp_tracker.py
+++ b/archive/ms11-core/xp_tracker.py
@@ -3,7 +3,6 @@ XP Tracker module for Android MS11.
 Combines OCR and heuristic estimation to track character progression.
 """
 
-import time
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -102,15 +102,9 @@ __all__ = [
     "display_themepark_progress",
     "render_themepark_table",
     "show_unified_dashboard",
+    "STATUS_COMPLETED",
+    "STATUS_FAILED",
+    "STATUS_IN_PROGRESS",
+    "STATUS_NOT_STARTED",
+    "STATUS_UNKNOWN",
 ]
-
-# Export status constants for ``from core import *`` usage
-__all__.extend(
-    [
-        "STATUS_COMPLETED",
-        "STATUS_FAILED",
-        "STATUS_IN_PROGRESS",
-        "STATUS_NOT_STARTED",
-        "STATUS_UNKNOWN",
-    ]
-)

--- a/core/legacy_loop.py
+++ b/core/legacy_loop.py
@@ -1,5 +1,4 @@
 import time
-from typing import List
 
 from utils.logger import logger
 from core.legacy_tracker import load_legacy_steps, read_quest_log

--- a/core/profession_manager.py
+++ b/core/profession_manager.py
@@ -1,7 +1,7 @@
 """Utilities for managing profession skill training."""
 
 from __future__ import annotations
-from typing import List, Dict
+from typing import Dict
 
 from utils.movement_manager import travel_to
 from utils.npc_handler import interact_with_trainer

--- a/core/trainer_ocr.py
+++ b/core/trainer_ocr.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 from PIL import Image

--- a/discord_relay.py
+++ b/discord_relay.py
@@ -1,4 +1,3 @@
-import asyncio
 import discord
 from discord.ext import commands
 from utils.logger import logger

--- a/modules/travel/trainer_travel.py
+++ b/modules/travel/trainer_travel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict
 
 from core.waypoint_verifier import verify_waypoint_stability
 from scripts.travel import shuttle

--- a/scripts/logic/trainer_navigator.py
+++ b/scripts/logic/trainer_navigator.py
@@ -13,7 +13,7 @@ import math
 import os
 import json
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from utils.load_trainers import load_trainers
 from utils.get_trainer_location import get_trainer_location

--- a/src/main.py
+++ b/src/main.py
@@ -4,8 +4,7 @@ import argparse
 import json
 import os
 import threading
-import time
-from typing import Dict, Any, Mapping, List
+from typing import Dict, Any, Mapping
 
 try:
     from discord.ext import commands

--- a/tests/core/test_shuttle_travel.py
+++ b/tests/core/test_shuttle_travel.py
@@ -1,4 +1,3 @@
-import pytest
 
 from core.shuttle_travel import get_shuttle_path
 

--- a/tests/core/test_train_manager.py
+++ b/tests/core/test_train_manager.py
@@ -1,5 +1,4 @@
 import logging
-import pytest
 from core.train_manager import TrainManager
 
 

--- a/tests/farming/test_terminal_farm.py
+++ b/tests/farming/test_terminal_farm.py
@@ -1,9 +1,6 @@
-import os
-import sys
 
 
 from modules.farming.terminal_farm import TerminalFarmer
-import core.session_tracker as session_tracker
 
 
 def test_parse_missions_filters_invalid_lines():

--- a/tests/test_automator_modes.py
+++ b/tests/test_automator_modes.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import pytest
 
 

--- a/tests/test_bounty_farming_mode.py
+++ b/tests/test_bounty_farming_mode.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_build_manager.py
+++ b/tests/test_build_manager.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.state.character import update_location, log_quest_progress, character_state

--- a/tests/test_check_and_train_skills.py
+++ b/tests/test_check_and_train_skills.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 import src.main as main

--- a/tests/test_check_buff_status.py
+++ b/tests/test_check_buff_status.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from utils.check_buff_status import update_buff_state

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.main import parse_args

--- a/tests/test_cli_reload.py
+++ b/tests/test_cli_reload.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_combat_profiles.py
+++ b/tests/test_combat_profiles.py
@@ -1,7 +1,4 @@
 import json
-import os
-import sys
-from pathlib import Path
 
 
 from modules.combat.profiles import load_combat_profile

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.execution.core import execute_step

--- a/tests/test_core_location_selector.py
+++ b/tests/test_core_location_selector.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from core import location_selector

--- a/tests/test_core_progress_tracker.py
+++ b/tests/test_core_progress_tracker.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_core_session_tracker.py
+++ b/tests/test_core_session_tracker.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from pathlib import Path
 
 

--- a/tests/test_core_xp_estimator.py
+++ b/tests/test_core_xp_estimator.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 from pathlib import Path
 import pytest

--- a/tests/test_dialogue.py
+++ b/tests/test_dialogue.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import random
 import time
 

--- a/tests/test_discord_relay.py
+++ b/tests/test_discord_relay.py
@@ -1,6 +1,4 @@
-import os
 import sys
-import os
 import sys
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_execute_quest_cli.py
+++ b/tests/test_execute_quest_cli.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_extract_trainers.py
+++ b/tests/test_extract_trainers.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from scripts.data import extract_trainers

--- a/tests/test_farm_profile_loader.py
+++ b/tests/test_farm_profile_loader.py
@@ -1,6 +1,4 @@
 import json
-import os
-import sys
 import pytest
 
 

--- a/tests/test_feedback_step_executor.py
+++ b/tests/test_feedback_step_executor.py
@@ -1,6 +1,5 @@
-import os
 import sys
-from types import SimpleNamespace, ModuleType
+from types import ModuleType
 
 
 from src.game_state.feedback import watch_text

--- a/tests/test_fetch_legacy_html.py
+++ b/tests/test_fetch_legacy_html.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import types
 

--- a/tests/test_find_trainer_cli.py
+++ b/tests/test_find_trainer_cli.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_game_bridge.py
+++ b/tests/test_game_bridge.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_grind_mode.py
+++ b/tests/test_grind_mode.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from modules.grinding import grind_mode

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from types import ModuleType
 

--- a/tests/test_learning_xp_estimator.py
+++ b/tests/test_learning_xp_estimator.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_legacy_quest_manager.py
+++ b/tests/test_legacy_quest_manager.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_license_hooks.py
+++ b/tests/test_license_hooks.py
@@ -1,6 +1,4 @@
-import os
 import warnings
-import sys
 
 
 from utils.license_hooks import requires_license

--- a/tests/test_location_selector.py
+++ b/tests/test_location_selector.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from modules.travel import location_selector

--- a/tests/test_log_manager.py
+++ b/tests/test_log_manager.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.log_manager import start_log

--- a/tests/test_log_progress.py
+++ b/tests/test_log_progress.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from unittest.mock import MagicMock
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 
 from src.logging.session_log import log_step

--- a/tests/test_main_auto_train.py
+++ b/tests/test_main_auto_train.py
@@ -1,6 +1,4 @@
 import argparse
-import os
-import sys
 from importlib import reload
 
 

--- a/tests/test_main_config.py
+++ b/tests/test_main_config.py
@@ -1,5 +1,4 @@
 import json
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_main_farming_target.py
+++ b/tests/test_main_farming_target.py
@@ -1,6 +1,4 @@
 import argparse
-import os
-import sys
 from importlib import reload
 
 

--- a/tests/test_main_smart_monitor.py
+++ b/tests/test_main_smart_monitor.py
@@ -1,6 +1,4 @@
 import importlib
-import os
-import sys
 
 
 from core import profile_loader, state_tracker, mode_selector

--- a/tests/test_medic_cli.py
+++ b/tests/test_medic_cli.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_mob_affinity_loader.py
+++ b/tests/test_mob_affinity_loader.py
@@ -1,10 +1,8 @@
 import json
-import os
-import sys
 from pathlib import Path
 
 
-from utils.load_mob_affinity import load_mob_affinity, MOB_AFFINITY_FILE
+from utils.load_mob_affinity import load_mob_affinity
 
 
 def test_load_mob_affinity_missing(monkeypatch):

--- a/tests/test_mode_scheduler.py
+++ b/tests/test_mode_scheduler.py
@@ -1,6 +1,4 @@
-import os
 import sys
-import pytest
 
 
 from core.mode_scheduler import get_next_mode

--- a/tests/test_mode_selector.py
+++ b/tests/test_mode_selector.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import pytest
 
 

--- a/tests/test_mode_stubs.py
+++ b/tests/test_mode_stubs.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from android_ms11.modes.medic_mode import start_medic

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import importlib
 import pytest
 from core import profile_loader, state_tracker

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.execution.movement import execute_movement

--- a/tests/test_next_quest.py
+++ b/tests/test_next_quest.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from unittest.mock import MagicMock
 
 

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from unittest.mock import MagicMock
 
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import types
 from PIL import Image

--- a/tests/test_parse_legacy_quest_html.py
+++ b/tests/test_parse_legacy_quest_html.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import json
 import types

--- a/tests/test_pre_buff_manager.py
+++ b/tests/test_pre_buff_manager.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from android_ms11.core.pre_buff_manager import apply_pre_buffs

--- a/tests/test_profession_importer.py
+++ b/tests/test_profession_importer.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import json
 import types

--- a/tests/test_profession_leveler.py
+++ b/tests/test_profession_leveler.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_profession_manager.py
+++ b/tests/test_profession_manager.py
@@ -1,10 +1,6 @@
-import os
-import sys
-import bs4
 
 
 from core.profession_manager import ProfessionManager
-import utils.ocr_scanner as ocr_scanner
 
 
 def test_train_missing_skills_travels(monkeypatch):

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -1,6 +1,4 @@
 import json
-import os
-import sys
 from pathlib import Path
 import pytest
 

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 import pytest
 

--- a/tests/test_progress_tracker_session.py
+++ b/tests/test_progress_tracker_session.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 from pathlib import Path
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,7 +1,4 @@
-import os
-import sys
 from unittest.mock import MagicMock
-import pytest
 
 
 from src.db import queries

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.execution.quest import execute_quest

--- a/tests/test_quest_engine_retry.py
+++ b/tests/test_quest_engine_retry.py
@@ -1,4 +1,3 @@
-import os
 from core import quest_engine
 
 def test_log_retry_creates_csv(tmp_path, monkeypatch):

--- a/tests/test_quest_executor.py
+++ b/tests/test_quest_executor.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.quest_executor import execute_quest

--- a/tests/test_quest_monitor.py
+++ b/tests/test_quest_monitor.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import time
 
 

--- a/tests/test_quest_path.py
+++ b/tests/test_quest_path.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from unittest.mock import patch
 
 

--- a/tests/test_quest_selector.py
+++ b/tests/test_quest_selector.py
@@ -1,12 +1,9 @@
-import os
-import sys
 import sqlite3
 import json
 import random
 
 
 from src import quest_selector
-from src.db import database
 
 
 def make_db():

--- a/tests/test_random_quest_cli.py
+++ b/tests/test_random_quest_cli.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_repeat_mode.py
+++ b/tests/test_repeat_mode.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.main import parse_args

--- a/tests/test_run_validated_step_with_ocr.py
+++ b/tests/test_run_validated_step_with_ocr.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 from types import ModuleType

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_runtime_profile.py
+++ b/tests/test_runtime_profile.py
@@ -1,6 +1,4 @@
 import json
-import os
-import sys
 from importlib import reload
 
 

--- a/tests/test_session_logging_with_xp.py
+++ b/tests/test_session_logging_with_xp.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,7 +1,4 @@
-import os
 import json
-import sys
-from datetime import datetime, timedelta
 
 
 from core.session_manager import SessionManager

--- a/tests/test_session_monitor.py
+++ b/tests/test_session_monitor.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from core.session_monitor import monitor_session

--- a/tests/test_shuttle_travel.py
+++ b/tests/test_shuttle_travel.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from scripts.travel import shuttle

--- a/tests/test_source_verifier.py
+++ b/tests/test_source_verifier.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from utils.source_verifier import file_changed, verify_source

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 from types import ModuleType

--- a/tests/test_state_tracker.py
+++ b/tests/test_state_tracker.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import json
 from importlib import reload
 

--- a/tests/test_states_mapping.py
+++ b/tests/test_states_mapping.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.vision import register_state, detect_state, handle_state

--- a/tests/test_story_generator.py
+++ b/tests/test_story_generator.py
@@ -1,6 +1,4 @@
-import os
 import sys
-import pytest
 from unittest.mock import MagicMock, patch, ANY
 import types
 

--- a/tests/test_themepark_tracker.py
+++ b/tests/test_themepark_tracker.py
@@ -1,5 +1,3 @@
-import sys
-import os
 import importlib.util
 from pathlib import Path
 

--- a/tests/test_trainer_find_cli.py
+++ b/tests/test_trainer_find_cli.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from importlib import reload
 

--- a/tests/test_trainer_navigator.py
+++ b/tests/test_trainer_navigator.py
@@ -1,7 +1,4 @@
-import os
-import sys
 import json
-from importlib import reload
 
 
 from scripts.logic import trainer_navigator as tn

--- a/tests/test_trainer_ocr.py
+++ b/tests/test_trainer_ocr.py
@@ -1,9 +1,6 @@
-import os
-import sys
 
 
 from core import trainer_ocr
-import pytesseract
 
 
 def test_get_untrained_skills_from_text():

--- a/tests/test_trainer_scanner.py
+++ b/tests/test_trainer_scanner.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from PIL import Image
 
 

--- a/tests/test_trainer_seeker.py
+++ b/tests/test_trainer_seeker.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from modules.training import trainer_seeker

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from src.automation.training import train_with_npc

--- a/tests/test_training_check.py
+++ b/tests/test_training_check.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from modules.skills import training_check

--- a/tests/test_travel_to_trainer.py
+++ b/tests/test_travel_to_trainer.py
@@ -1,10 +1,7 @@
-import os
-import sys
 
 
 from modules.travel import trainer_travel
 from scripts.travel import shuttle
-from src.movement import movement_profiles
 
 
 def test_travel_to_trainer_invokes_navigation(monkeypatch):

--- a/tests/test_waypoint_verifier.py
+++ b/tests/test_waypoint_verifier.py
@@ -1,5 +1,3 @@
-import os
-import sys
 
 
 from core.waypoint_verifier import verify_waypoint_stability

--- a/tests/test_wiki_scraper.py
+++ b/tests/test_wiki_scraper.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import types
 import pytest

--- a/tests/test_xp_manager.py
+++ b/tests/test_xp_manager.py
@@ -1,7 +1,4 @@
-import os
-import sys
 from unittest.mock import MagicMock
-import pytest
 
 
 from src.xp_manager import XPManager

--- a/utils/fetch_legacy_html.py
+++ b/utils/fetch_legacy_html.py
@@ -1,6 +1,5 @@
 # src/utils/fetch_legacy_html.py
 
-import os
 from pathlib import Path
 from playwright.sync_api import sync_playwright
 

--- a/utils/screen_capture.py
+++ b/utils/screen_capture.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Tuple, Optional
+from typing import Tuple
 
 import pyautogui
 

--- a/utils/travel.py
+++ b/utils/travel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Sequence, Tuple, Any, Optional
+from typing import Iterable, Sequence, Any, Optional
 
 from modules.travel.location_selector import select_target
 from src.movement.movement_profiles import walk_to_coords

--- a/utils/window_finder.py
+++ b/utils/window_finder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import Iterable
 
 import pygetwindow
 


### PR DESCRIPTION
## Summary
- run `ruff --fix` to drop unused imports across the repo
- inline core status constants in `__all__`

## Testing
- `pytest -q`
- `ruff check --select F401 .`


------
https://chatgpt.com/codex/tasks/task_b_686b812de8e88331a2ddca3dbbfdeeb1