### PR TITLE
Fix quest step not-started status

### DIFF
--- a/core/quest_state.py
+++ b/core/quest_state.py
@@ -77,7 +77,7 @@ def get_step_status(step_id: str, log_lines: Optional[List[str]] = None) -> str:
                 return STATUS_COMPLETED
             if "progress" in lowered or "started" in lowered or "in progress" in lowered:
                 return STATUS_IN_PROGRESS
-    return STATUS_UNKNOWN
+    return STATUS_NOT_STARTED
 
 
 __all__ = [

--- a/tests/test_legacy_dashboard.py
+++ b/tests/test_legacy_dashboard.py
@@ -11,7 +11,7 @@ def test_display_legacy_progress(monkeypatch, capsys):
     legacy_dashboard.display_legacy_progress(steps)
     captured = capsys.readouterr()
     assert "✅ Completed" in captured.out
-    assert "❓ Unknown" in captured.out
+    assert "🕒 Not Started" in captured.out
 
 
 def test_enriched_status_output(monkeypatch, capsys):

--- a/tests/test_quest_state.py
+++ b/tests/test_quest_state.py
@@ -29,4 +29,4 @@ def test_get_step_status(tmp_path, monkeypatch):
     assert qs.get_step_status("1") == qs.STATUS_COMPLETED
     assert qs.get_step_status("2") == qs.STATUS_FAILED
     assert qs.get_step_status("3") == qs.STATUS_IN_PROGRESS
-    assert qs.get_step_status("4") == qs.STATUS_UNKNOWN
+    assert qs.get_step_status("4") == qs.STATUS_NOT_STARTED


### PR DESCRIPTION
## Summary
- treat missing log entries as `STATUS_NOT_STARTED`
- adjust legacy dashboard and quest state tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b86a283f8833187a84598e49dcd4b