### PR TITLE
Add show_legacy_dashboard helper

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -92,6 +92,7 @@ __all__ = [
     "run_full_legacy_quest",
     "display_legacy_progress",
     "render_legacy_table",
+    "show_legacy_dashboard",
     "parse_quest_log",
     "is_step_completed",
     "scan_log_file_for_step",

--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -61,4 +61,16 @@ def display_legacy_progress(quest_steps: list, *, summary: bool = False) -> None
     Console().print(build_legacy_progress_table(quest_steps, summary=summary))
 
 
-__all__ = ["build_legacy_progress_table", "display_legacy_progress", "render_legacy_table"]
+def show_legacy_dashboard(*, summary: bool = False) -> None:
+    """Load legacy quest steps and display them."""
+
+    steps = load_legacy_steps()
+    display_legacy_progress(steps, summary=summary)
+
+
+__all__ = [
+    "build_legacy_progress_table",
+    "display_legacy_progress",
+    "render_legacy_table",
+    "show_legacy_dashboard",
+]

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 
 from core.legacy_loop import run_full_legacy_quest
-from core.legacy_dashboard import display_legacy_progress
+from core.legacy_dashboard import display_legacy_progress, show_legacy_dashboard
 from core.legacy_tracker import load_legacy_steps
 from core.themepark_dashboard import display_themepark_progress
 from core.themepark_tracker import load_themepark_chains

--- a/tests/test_legacy_dashboard.py
+++ b/tests/test_legacy_dashboard.py
@@ -24,3 +24,20 @@ def test_enriched_status_output(capsys):
     assert STATUS_EMOJI_MAP["completed"] in captured.out
     assert STATUS_EMOJI_MAP["failed"] in captured.out
     assert STATUS_EMOJI_MAP["in_progress"] in captured.out
+
+
+def test_show_legacy_dashboard(monkeypatch):
+    """Ensure ``show_legacy_dashboard`` loads steps and displays them."""
+
+    called = {}
+
+    monkeypatch.setattr(legacy_dashboard, "load_legacy_steps", lambda: [1])
+    monkeypatch.setattr(
+        legacy_dashboard,
+        "display_legacy_progress",
+        lambda steps, summary=False: called.setdefault("steps", steps),
+    )
+
+    legacy_dashboard.show_legacy_dashboard()
+
+    assert called.get("steps") == [1]


### PR DESCRIPTION
## Summary
- provide `show_legacy_dashboard` in `core.legacy_dashboard`
- export new helper from `core.__init__`
- import helper in `main.py`
- test show_legacy_dashboard behaviour

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_686c47e01070833189a6465ab72b5605