### PR TITLE
Add dashboard status filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The original MS11-Core implementation has been archived under `archive/ms11-core
 - 🎡 Theme Park Dashboard: View progress with `--show-themepark-status`
 - 🖥️ Unified Dashboard CLI: view both dashboards with `--show-dashboard`, switch
   tables with `--dashboard-mode`, toggle `--summary`/`--detailed`, and filter
-  by status using `--filter-status`
+  quest rows using `--filter-status`
 - ✅ Smart Retry Logic: automatically retries failed quest steps up to 3 times, writing details to `logs/retry_log.txt`
 - 📊 Quest Step Enrichment (Completed / Failed / In Progress / Unknown)
 

--- a/codex_validation_batch_044.py
+++ b/codex_validation_batch_044.py
@@ -60,7 +60,7 @@ def main() -> None:
         "--dashboard-mode",
         "--summary",
         "--detailed",
-        "--filter",
+        "--filter-status",
     ]
 
     dashboard_funcs = [

--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -20,6 +20,7 @@ def show_unified_dashboard(
     mode: str = "all",
     legacy_steps: list | None = None,
     summary: bool = False,
+    filter_status: str | None = None,
 ) -> None:
     """Print a dashboard with quest progress based on ``mode``."""
 
@@ -33,6 +34,16 @@ def show_unified_dashboard(
         legacy_steps = load_legacy_steps()
     if themepark_quests is None:
         themepark_quests = load_themepark_chains()
+
+    if filter_status:
+        if mode in {"legacy", "all"}:
+            legacy_steps = [
+                s for s in legacy_steps if get_step_status(s) == filter_status
+            ]
+        if mode in {"themepark", "all"}:
+            themepark_quests = [
+                q for q in themepark_quests if get_themepark_status(q) == filter_status
+            ]
 
     if summary:
         categories: dict[str, list[str]] = {}

--- a/main.py
+++ b/main.py
@@ -44,6 +44,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="all",
         help="Select sections to display in the dashboard",
     )
+    parser.add_argument(
+        "--filter-status",
+        dest="filter_status",
+        help="Only display rows matching the given status emoji",
+    )
     return parser.parse_args(argv)
 
 
@@ -59,7 +64,9 @@ def main(argv: list[str] | None = None) -> None:
         display_themepark_progress(load_themepark_chains())
 
     if args.show_dashboard:
-        show_unified_dashboard(mode=args.dashboard_mode)
+        show_unified_dashboard(
+            mode=args.dashboard_mode, filter_status=args.filter_status
+        )
         return
 
     if args.legacy or not (args.legacy or args.show_legacy_status or args.show_themepark_status):

--- a/tests/test_main_legacy_cli.py
+++ b/tests/test_main_legacy_cli.py
@@ -84,14 +84,20 @@ def test_parse_args_dashboard_mode(monkeypatch):
     assert args.show_dashboard is False
 
 
+def test_parse_args_filter_status(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--filter-status", "✅"])
+    args = legacy_main.parse_args()
+    assert args.filter_status == "✅"
+
+
 def test_main_show_dashboard(monkeypatch):
     legacy_main_mod = importlib.reload(legacy_main)
     called = {}
     monkeypatch.setattr(
         legacy_main_mod,
         "show_unified_dashboard",
-        lambda *, mode="all", summary=False, filter_emoji=None: called.setdefault(
-            "dashboard", (mode, summary, filter_emoji)
+        lambda *, mode="all", summary=False, filter_status=None: called.setdefault(
+            "dashboard", (mode, summary, filter_status)
         ),
     )
     monkeypatch.setattr(

--- a/tests/test_unified_dashboard.py
+++ b/tests/test_unified_dashboard.py
@@ -97,3 +97,20 @@ def test_show_unified_dashboard_summary(monkeypatch, capsys):
     assert "Legacy" in out
     assert "Theme Parks" in out
     assert render_progress_bar([STATUS_EMOJI_MAP["completed"]]) in out
+
+
+def test_show_unified_dashboard_filter(monkeypatch, capsys):
+    Console.printed.clear() if hasattr(Console, "printed") else None
+
+    steps = [
+        {"id": 1, "title": "Intro", "completed": True},
+        {"id": 2, "title": "Next"},
+    ]
+
+    monkeypatch.setattr(legacy_tracker, "load_legacy_steps", lambda: steps)
+    monkeypatch.setattr(tp, "load_themepark_chains", lambda: ["Jabba"])
+    monkeypatch.setattr(tp, "get_themepark_status", lambda q: STATUS_EMOJI_MAP["completed"])
+
+    unified.show_unified_dashboard(filter_status=STATUS_EMOJI_MAP["completed"])
+    out = capsys.readouterr().out
+    assert "Next" not in out


### PR DESCRIPTION
## Summary
- allow filtering quest rows by status emoji
- plumb `--filter-status` flag through CLI
- filter rows in `show_unified_dashboard`
- cover new CLI flag with tests
- verify flag presence in the batch validation script
- document the option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c502426f88331a1267d2ac34fb8a1