### PR TITLE
Fix Makefile validate recipe tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ test:
 	pytest -q --tb=short
 
 validate:
-        @echo "\n🔍 Running QA validation script..."
-        @python codex_validation_check.py
-        @echo "\n🧪 Running full test suite..."
-        @pytest -q --tb=short
+	@echo "\n🔍 Running QA validation script..."
+	@python codex_validation_check.py
+	@echo "\n🧪 Running full test suite..."
+	@pytest -q --tb=short
 
 validate-batch-044:
 	python codex_validation_batch_044.py


### PR DESCRIPTION
## Summary
- convert spaces to tabs for all `validate` recipes in Makefile

## Testing
- `make test`
- `make validate`


------
https://chatgpt.com/codex/tasks/task_b_686c52e730248331b33b6a37962597f2