### PR TITLE
Add dashboard utilities and validation for batch 046

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test validate validate-batch-044 validate-batch-045
+.PHONY: install test validate validate-batch-044 validate-batch-045 validate-batch-046
 
 install:
 	pip install -r requirements.txt
@@ -17,4 +17,7 @@ validate-batch-044:
 	python codex_validation_batch_044.py
 
 validate-batch-045:
-	python codex_validation_batch_045.py
+        python codex_validation_batch_045.py
+
+validate-batch-046:
+        python codex_validation_batch_046.py

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The original MS11-Core implementation has been archived under `archive/ms11-core
   quest rows using `--filter-status`
 - ✅ Smart Retry Logic: automatically retries failed quest steps up to 3 times, writing details to `logs/retry_log.txt`
 - 📊 Quest Step Enrichment (Completed / Failed / In Progress / Unknown)
+- 🔗 Dashboard Utils for grouping quests and summary counts
 
 ## Lore
 In the world of **Argent**, legendary guilds compete to recover ancient relics. Adventurers take on perilous quests to gain favor with their faction and earn the power needed to reunite the shards. Android MS11 provides the tooling to script and observe these journeys, whether you are tracking combat victories or following a sprawling roleplay narrative.
@@ -527,6 +528,7 @@ Filter rows by status emoji with `--filter-status`:
 ```bash
 python main.py --show-dashboard --filter-status ✅
 ```
+Summary mode displays total quest counts per category when filtering.
 
 The split layout places the legacy table above the theme park table using Rich's
 `Layout` class.

--- a/codex_validation_batch_046.py
+++ b/codex_validation_batch_046.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).parent
+
+
+def check_exists(path: str) -> bool:
+    p = ROOT / path
+    if p.exists():
+        print(f"[OK] {path}")
+        return True
+    print(f"[MISSING] {path}")
+    return False
+
+
+def check_contains(path: str, text: str) -> bool:
+    file_path = ROOT / path
+    if not file_path.exists():
+        print(f"[MISSING FILE] {path}")
+        return False
+    if text in file_path.read_text():
+        print(f"[OK] {text}")
+        return True
+    print(f"[MISSING] {text}")
+    return False
+
+
+def main() -> None:
+    required_files = [
+        "core/dashboard_utils.py",
+        "core/unified_dashboard.py",
+        "core/legacy_dashboard.py",
+        "docs/batch_summary.md",
+        "README.md",
+        "Makefile",
+        "main.py",
+    ]
+
+    test_files = [
+        "tests/test_dashboard_filters.py",
+        "tests/test_unified_dashboard.py",
+        "tests/test_legacy_dashboard.py",
+    ]
+
+    cli_flags = ["--filter-status"]
+
+    summary_phrases = ["summary counts", "Dashboard Utils"]
+
+    print("Validating required files:\n")
+    missing_files = [f for f in required_files if not check_exists(f)]
+
+    print("\nChecking CLI flags in main.py:\n")
+    missing_flags = [flag for flag in cli_flags if not check_contains("main.py", flag)]
+
+    print("\nChecking test files:\n")
+    missing_tests = [t for t in test_files if not check_exists(t)]
+
+    print("\nChecking README for summary lines:\n")
+    missing_phrases = [p for p in summary_phrases if not check_contains("README.md", p)]
+
+    total_missing = len(missing_files) + len(missing_flags) + len(missing_tests) + len(missing_phrases)
+
+    print("\nValidation summary:")
+    print(f"  Missing files: {len(missing_files)}")
+    print(f"  Missing CLI flags: {len(missing_flags)}")
+    print(f"  Missing tests: {len(missing_tests)}")
+    print(f"  Missing README phrases: {len(missing_phrases)}")
+
+    if total_missing:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -57,6 +57,11 @@ from .constants import (
     STATUS_NAME_FROM_EMOJI,
     VALID_STATUS_EMOJIS,
 )
+from .dashboard_utils import (
+    group_quests_by_category,
+    build_summary_table,
+    print_summary_counts,
+)
 
 __all__ = [
     "preprocess_image",
@@ -106,6 +111,9 @@ __all__ = [
     "display_themepark_progress",
     "render_themepark_table",
     "show_unified_dashboard",
+    "group_quests_by_category",
+    "build_summary_table",
+    "print_summary_counts",
     "STATUS_COMPLETED",
     "STATUS_FAILED",
     "STATUS_IN_PROGRESS",

--- a/core/dashboard_utils.py
+++ b/core/dashboard_utils.py
@@ -1,0 +1,45 @@
+"""Shared utilities for building dashboard summaries."""
+
+from __future__ import annotations
+
+from typing import Iterable, Dict, List
+from rich.console import Console
+from rich.table import Table
+
+from .quest_state import get_step_status
+from .themepark_tracker import get_themepark_status
+from .utils import render_progress_bar
+
+
+def group_quests_by_category(
+    legacy_steps: Iterable[dict] | None = None,
+    themepark_quests: Iterable[str] | None = None,
+) -> Dict[str, List[str]]:
+    """Return a mapping of category name to status emoji list."""
+    categories: Dict[str, List[str]] = {}
+    if legacy_steps:
+        for step in legacy_steps:
+            cat = step.get("category", "Legacy")
+            categories.setdefault(cat, []).append(get_step_status(step))
+    if themepark_quests:
+        categories["Theme Parks"] = [get_themepark_status(q) for q in themepark_quests]
+    return categories
+
+
+def build_summary_table(categories: Dict[str, List[str]]) -> Table:
+    """Return a ``rich`` table showing progress bars and total counts."""
+    table = Table(title="Quest Progress Summary")
+    table.add_column("Category", style="bold")
+    table.add_column("Progress")
+    table.add_column("Count", justify="right")
+    for cat, statuses in categories.items():
+        table.add_row(cat, render_progress_bar(statuses), str(len(statuses)))
+    return table
+
+
+def print_summary_counts(categories: Dict[str, List[str]]) -> None:
+    """Render a progress summary table using :func:`Console.print`."""
+    Console().print(build_summary_table(categories))
+
+
+__all__ = ["group_quests_by_category", "build_summary_table", "print_summary_counts"]

--- a/core/legacy_dashboard.py
+++ b/core/legacy_dashboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 from rich.table import Table
 
-from .utils import render_progress_bar
+from .dashboard_utils import build_summary_table, group_quests_by_category
 
 from .legacy_tracker import load_legacy_steps
 
@@ -20,18 +20,8 @@ def build_legacy_progress_table(quest_steps: list, *, summary: bool = False) -> 
     """
 
     if summary:
-        table = Table(title="Legacy Quest Progress")
-        table.add_column("Category", style="bold")
-        table.add_column("Progress")
-
-        categories: dict[str, list[str]] = {}
-        for step in quest_steps:
-            category = step.get("category", "Legacy")
-            categories.setdefault(category, []).append(get_step_status(step))
-
-        for cat, statuses in categories.items():
-            table.add_row(cat, render_progress_bar(statuses))
-        return table
+        categories = group_quests_by_category(quest_steps)
+        return build_summary_table(categories)
 
     table = Table(title="Legacy Quest Progress", show_lines=True)
     table.add_column("Step ID", style="bold", no_wrap=True)

--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -11,7 +11,7 @@ from .legacy_dashboard import render_legacy_table
 from .themepark_tracker import load_themepark_chains, get_themepark_status
 from .themepark_dashboard import render_themepark_table
 from .quest_state import get_step_status
-from .utils import render_progress_bar
+from .dashboard_utils import build_summary_table, group_quests_by_category
 
 
 def show_unified_dashboard(
@@ -46,21 +46,11 @@ def show_unified_dashboard(
             ]
 
     if summary:
-        categories: dict[str, list[str]] = {}
-        if mode in {"legacy", "all"}:
-            for step in legacy_steps:
-                cat = step.get("category", "Legacy")
-                categories.setdefault(cat, []).append(get_step_status(step))
-        if mode in {"themepark", "all"}:
-            statuses = [get_themepark_status(q) for q in themepark_quests]
-            categories["Theme Parks"] = statuses
-
-        table = Table(title="Quest Progress Summary")
-        table.add_column("Category", style="bold")
-        table.add_column("Progress")
-        for cat, statuses in categories.items():
-            table.add_row(cat, render_progress_bar(statuses))
-        Console().print(table)
+        categories = group_quests_by_category(
+            legacy_steps if mode in {"legacy", "all"} else [],
+            themepark_quests if mode in {"themepark", "all"} else [],
+        )
+        Console().print(build_summary_table(categories))
         return
 
     legacy_table = render_legacy_table(legacy_steps, summary=summary)

--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -67,6 +67,12 @@
 - Expanded tests and README to cover the new dashboard features.
 - Added `codex_validation_batch_044.py` to validate required files and flags.
 
+## ✅ Batch 046
+- Factored common summary helpers into `core.dashboard_utils`.
+- Refactored dashboards to use the shared grouping logic.
+- Added tests covering filtered summaries and count output.
+- Included `codex_validation_batch_046.py` and Makefile target.
+
 ---
 
 To install dependencies and run validation:

--- a/tests/test_dashboard_filters.py
+++ b/tests/test_dashboard_filters.py
@@ -1,0 +1,45 @@
+import core.unified_dashboard as unified
+from core.constants import STATUS_EMOJI_MAP
+from core.dashboard_utils import group_quests_by_category, print_summary_counts
+from rich.console import Console
+
+
+def test_filter_status_grouped(monkeypatch, capsys):
+    Console.printed.clear() if hasattr(Console, "printed") else None
+    steps = [
+        {"id": 1, "title": "A", "category": "Tutorial", "completed": True},
+        {"id": 2, "title": "B", "category": "Combat", "completed": True},
+        {"id": 3, "title": "C", "category": "Tutorial"},
+    ]
+    monkeypatch.setattr(unified, "load_legacy_steps", lambda: steps)
+    monkeypatch.setattr(unified, "load_themepark_chains", lambda: [])
+    monkeypatch.setattr(
+        unified,
+        "get_step_status",
+        lambda step, log_lines=None: STATUS_EMOJI_MAP["completed"]
+        if step.get("completed")
+        else STATUS_EMOJI_MAP["not_started"],
+    )
+    unified.show_unified_dashboard(
+        mode="legacy",
+        summary=True,
+        filter_status=STATUS_EMOJI_MAP["completed"],
+    )
+    out = capsys.readouterr().out
+    assert "Quest Progress Summary" in out
+    assert "Tutorial" in out
+    assert "Combat" in out
+
+
+def test_print_summary_counts(monkeypatch, capsys):
+    Console.printed.clear() if hasattr(Console, "printed") else None
+    steps = [
+        {"id": 1, "title": "Intro", "category": "Tutorial", "completed": True},
+        {"id": 2, "title": "Next", "category": "Tutorial", "completed": True},
+    ]
+    monkeypatch.setattr(unified, "get_themepark_status", lambda q: STATUS_EMOJI_MAP["completed"])
+    categories = group_quests_by_category(steps, ["Jabba"])
+    print_summary_counts(categories)
+    out = capsys.readouterr().out
+    assert "Count" in out
+    assert "Quest Progress Summary" in out


### PR DESCRIPTION
## Summary
- share grouping logic via `core/dashboard_utils.py`
- refactor dashboards to use the shared helpers
- add `test_dashboard_filters.py` for grouped summaries
- create `codex_validation_batch_046.py` and makefile target
- document dashboard utils and summary counts
- update batch summary for Batch 046

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c8f55360c8331a38422839d5faa35