### PR TITLE
Add dashboard filter summary tests

### DIFF
--- a/tests/test_dashboard_filters.py
+++ b/tests/test_dashboard_filters.py
@@ -1,3 +1,4 @@
+import pytest
 import core.unified_dashboard as unified
 from core.constants import STATUS_EMOJI_MAP
 from core.dashboard_utils import group_quests_by_category, print_summary_counts
@@ -43,3 +44,37 @@ def test_print_summary_counts(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Count" in out
     assert "Quest Progress Summary" in out
+
+
+@pytest.mark.parametrize("status_key", ["completed", "in_progress", "not_started"])
+def test_show_unified_dashboard_filter_summary(monkeypatch, capsys, status_key):
+    """Dashboard summary should group quests and show only the filtered status."""
+
+    Console.printed.clear() if hasattr(Console, "printed") else None
+
+    steps = [
+        {"id": 1, "title": "Step A", "category": "Tutorial", status_key: True},
+        {"id": 2, "title": "Step B", "category": "Combat", status_key: True},
+        {"id": 3, "title": "Step C", "category": "Tutorial"},
+    ]
+
+    monkeypatch.setattr(unified, "load_legacy_steps", lambda: steps)
+    monkeypatch.setattr(unified, "load_themepark_chains", lambda: [])
+
+    def fake_status(step, log_lines=None):
+        return STATUS_EMOJI_MAP[status_key] if step.get(status_key) else STATUS_EMOJI_MAP["not_started"]
+
+    monkeypatch.setattr(unified, "get_step_status", fake_status)
+
+    unified.show_unified_dashboard(
+        mode="legacy",
+        summary=True,
+        filter_status=STATUS_EMOJI_MAP[status_key],
+    )
+    out = capsys.readouterr().out
+
+    assert "Quest Progress Summary" in out
+    assert "Tutorial" in out
+    assert "Combat" in out
+    assert STATUS_EMOJI_MAP[status_key] in out
+


### PR DESCRIPTION
## Summary
- cover dashboard summary filtering for all statuses

## Testing
- `pytest -q tests/test_dashboard_filters.py -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686cac7297088331ba8d2620c833b7f7