### PR TITLE
Fix combat init imports

### DIFF
--- a/ai/combat/__init__.py
+++ b/ai/combat/__init__.py
@@ -1,5 +1,5 @@
 """Compat module exposing combat AI runtime from ``src.ai``."""
 
-from src.ai.combat import *  # re-export everything for backwards compatibility
+from src.ai.combat import evaluate_state, CombatRunner
 
 __all__ = ["evaluate_state", "CombatRunner"]


### PR DESCRIPTION
## Summary
- import CombatRunner and evaluate_state explicitly in `ai.combat`

## Testing
- `ruff check ai/combat/__init__.py`

------
https://chatgpt.com/codex/tasks/task_b_686cba2b15788331b7efa2db0e16b125