### PR TITLE
Implement batch 048 dashboard helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test validate validate-batch-044 validate-batch-045 validate-batch-046 validate-batch-047
+.PHONY: install test validate validate-batch-044 validate-batch-045 validate-batch-046 validate-batch-047 validate-048
 
 install:
 	pip install -r requirements.txt
@@ -23,4 +23,7 @@ validate-batch-046:
 	python codex_validation_batch_046.py
 
 validate-batch-047:
-	python codex_validation_batch_047.py
+        python codex_validation_batch_047.py
+
+validate-048:
+        python scripts/codex_validation_batch_048.py

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -61,6 +61,9 @@ from .dashboard_utils import (
     group_quests_by_category,
     build_summary_table,
     print_summary_counts,
+    group_steps_by_category,
+    summarize_status_counts,
+    calculate_completion_percentage,
 )
 
 __all__ = [
@@ -114,6 +117,9 @@ __all__ = [
     "group_quests_by_category",
     "build_summary_table",
     "print_summary_counts",
+    "group_steps_by_category",
+    "summarize_status_counts",
+    "calculate_completion_percentage",
     "STATUS_COMPLETED",
     "STATUS_FAILED",
     "STATUS_IN_PROGRESS",

--- a/core/dashboard_utils.py
+++ b/core/dashboard_utils.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from typing import Iterable, Dict, List
+from collections import Counter
+
+from .constants import STATUS_COMPLETED, VALID_STATUS_EMOJIS
 from rich.console import Console
 from rich.table import Table
 
@@ -42,4 +45,41 @@ def print_summary_counts(categories: Dict[str, List[str]]) -> None:
     Console().print(build_summary_table(categories))
 
 
-__all__ = ["group_quests_by_category", "build_summary_table", "print_summary_counts"]
+def group_steps_by_category(
+    legacy_steps: Iterable[dict] | None = None,
+    themepark_quests: Iterable[str] | None = None,
+) -> Dict[str, List]:
+    """Return a mapping of category name to quest step objects."""
+    categories: Dict[str, List] = {}
+    if legacy_steps:
+        for step in legacy_steps:
+            cat = step.get("category", "Legacy")
+            categories.setdefault(cat, []).append(step)
+    if themepark_quests:
+        categories["Theme Parks"] = list(themepark_quests)
+    return categories
+
+
+def summarize_status_counts(statuses: Iterable[str]) -> Dict[str, int]:
+    """Return a count of each status emoji in ``statuses``."""
+    counts = Counter(statuses)
+    return {emoji: counts.get(emoji, 0) for emoji in VALID_STATUS_EMOJIS}
+
+
+def calculate_completion_percentage(status_counts: Dict[str, int]) -> float:
+    """Return percent of steps marked completed in ``status_counts``."""
+    total = sum(status_counts.values())
+    if total == 0:
+        return 0.0
+    completed = status_counts.get(STATUS_COMPLETED, 0)
+    return round(completed * 100 / total, 2)
+
+
+__all__ = [
+    "group_quests_by_category",
+    "build_summary_table",
+    "print_summary_counts",
+    "group_steps_by_category",
+    "summarize_status_counts",
+    "calculate_completion_percentage",
+]

--- a/core/unified_dashboard.py
+++ b/core/unified_dashboard.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 from rich.console import Console
-from rich.layout import Layout
-from rich.table import Table
+
 
 from .legacy_tracker import load_legacy_steps
 from .legacy_dashboard import render_legacy_table
 from .themepark_tracker import load_themepark_chains, get_themepark_status
 from .themepark_dashboard import render_themepark_table
 from .quest_state import get_step_status
-from .dashboard_utils import build_summary_table, group_quests_by_category
+from .dashboard_utils import (
+    build_summary_table,
+    group_quests_by_category,
+    group_steps_by_category,
+    summarize_status_counts,
+    calculate_completion_percentage,
+)
 
 
 def show_unified_dashboard(
@@ -45,31 +50,33 @@ def show_unified_dashboard(
                 q for q in themepark_quests if get_themepark_status(q) == filter_status
             ]
 
-    if summary:
-        categories = group_quests_by_category(
-            legacy_steps if mode in {"legacy", "all"} else [],
-            themepark_quests if mode in {"themepark", "all"} else [],
-        )
-        Console().print(build_summary_table(categories))
-        return
-
-    legacy_table = render_legacy_table(legacy_steps, summary=summary)
-    themepark_table = render_themepark_table(themepark_quests)
-
-    if mode == "legacy":
-        Console().print(legacy_table)
-        return
-    if mode == "themepark":
-        Console().print(themepark_table)
-        return
-
-    layout = Layout()
-    layout.split_column(
-        Layout(legacy_table, name="legacy"),
-        Layout(themepark_table, name="themepark"),
+    categories = group_quests_by_category(
+        legacy_steps if mode in {"legacy", "all"} else [],
+        themepark_quests if mode in {"themepark", "all"} else [],
     )
 
-    Console().print(layout)
+    step_groups = group_steps_by_category(
+        legacy_steps if mode in {"legacy", "all"} else [],
+        themepark_quests if mode in {"themepark", "all"} else [],
+    )
+
+    for cat, steps in step_groups.items():
+        status_list = categories.get(cat, [])
+        counts = summarize_status_counts(status_list)
+        summary_line = " ".join(
+            f"{emoji}{count}" for emoji, count in counts.items() if count
+        )
+        percent = calculate_completion_percentage(counts)
+        Console().print(f"{cat}: {summary_line} ({percent:.0f}% complete)")
+        if summary:
+            continue
+        if cat == "Theme Parks":
+            Console().print(render_themepark_table(steps))
+        else:
+            Console().print(render_legacy_table(steps, summary=False))
+
+    if summary:
+        Console().print(build_summary_table(categories))
 
 
 __all__ = ["show_unified_dashboard"]

--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -85,6 +85,12 @@
 - Introduced a new validation script to check the dashboard options.
 - Included `codex_validation_batch_047.py` and Makefile target.
 
+## ✅ Batch 048
+- Added helpers for grouping steps and computing completion percentages.
+- Dashboards now print per-category emoji summaries with completion rates.
+- Extended tests and a validation script for the new utilities.
+- Included `codex_validation_batch_048.py` and Makefile target.
+
 ---
 
 To install dependencies and run validation:

--- a/scripts/codex_validation_batch_048.py
+++ b/scripts/codex_validation_batch_048.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def check_exists(path: str) -> bool:
+    p = ROOT / path
+    if p.exists():
+        print(f"[OK] {path}")
+        return True
+    print(f"[MISSING] {path}")
+    return False
+
+
+def check_contains(path: str, text: str) -> bool:
+    file_path = ROOT / path
+    if not file_path.exists():
+        print(f"[MISSING FILE] {path}")
+        return False
+    if text in file_path.read_text():
+        print(f"[OK] {text}")
+        return True
+    print(f"[MISSING] {text}")
+    return False
+
+
+def main() -> None:
+    required_files = [
+        "core/dashboard_utils.py",
+        "core/unified_dashboard.py",
+        "docs/batch_summary.md",
+        "tests/test_dashboard_utils.py",
+    ]
+
+    functions = [
+        "group_steps_by_category",
+        "summarize_status_counts",
+        "calculate_completion_percentage",
+    ]
+
+    print("Validating required files:\n")
+    missing_files = [f for f in required_files if not check_exists(f)]
+
+    print("\nChecking dashboard utils for functions:\n")
+    missing_defs = [f for f in functions if not check_contains("core/dashboard_utils.py", f)]
+
+    print("\nChecking unified dashboard usage:\n")
+    missing_usage = [f for f in functions if not check_contains("core/unified_dashboard.py", f)]
+
+    print("\nChecking batch summary for entry:\n")
+    summary_missing = 0 if check_contains("docs/batch_summary.md", "Batch 048") else 1
+
+    total_missing = len(missing_files) + len(missing_defs) + len(missing_usage) + summary_missing
+
+    print("\nValidation summary:")
+    print(f"  Missing files: {len(missing_files)}")
+    print(f"  Missing definitions: {len(missing_defs)}")
+    print(f"  Missing usage: {len(missing_usage)}")
+    print(f"  Missing summary entry: {summary_missing}")
+
+    if total_missing:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -1,5 +1,29 @@
-from core.dashboard_utils import group_quests_by_category
+from core.dashboard_utils import (
+    group_quests_by_category,
+    summarize_status_counts,
+    calculate_completion_percentage,
+)
+from core.constants import STATUS_EMOJI_MAP
 
 
 def test_group_quests_by_category_empty():
     assert group_quests_by_category() == {}
+
+
+def test_summarize_status_counts():
+    statuses = [
+        STATUS_EMOJI_MAP["completed"],
+        STATUS_EMOJI_MAP["completed"],
+        STATUS_EMOJI_MAP["in_progress"],
+    ]
+    counts = summarize_status_counts(statuses)
+    assert counts[STATUS_EMOJI_MAP["completed"]] == 2
+    assert counts[STATUS_EMOJI_MAP["in_progress"]] == 1
+
+
+def test_calculate_completion_percentage():
+    counts = {
+        STATUS_EMOJI_MAP["completed"]: 3,
+        STATUS_EMOJI_MAP["in_progress"]: 1,
+    }
+    assert calculate_completion_percentage(counts) == 75.0


### PR DESCRIPTION
## Summary
- expand dashboard utilities with step grouping and completion helpers
- show per-category summaries and percentages on the unified dashboard
- test new helpers and document dashboard updates
- add validation script `codex_validation_batch_048.py`
- provide `validate-048` Makefile target

## Testing
- `pytest -q tests/test_dashboard_utils.py::test_summarize_status_counts tests/test_dashboard_utils.py::test_calculate_completion_percentage -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686cbcd45a3c83318e6ad68726e2611e