### PR TITLE
Fix quest file encoding

### DIFF
--- a/src/execution/quest_executor.py
+++ b/src/execution/quest_executor.py
@@ -22,7 +22,7 @@ class QuestExecutor:
 
     def load_steps(self) -> list[dict]:
         """Load quest step dictionaries from ``quest_path``."""
-        with open(self.quest_path, "r") as file:
+        with open(self.quest_path, "r", encoding="utf-8") as file:
             return json.load(file)
 
     def run(self) -> None:


### PR DESCRIPTION
## Summary
- specify UTF-8 encoding when loading quest JSON in `QuestExecutor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d34677c98833185bab0c893a516f6