### PR TITLE
Refactor quest executors to share core logic

### DIFF
--- a/src/execution/quest_executor.py
+++ b/src/execution/quest_executor.py
@@ -8,10 +8,9 @@ in-game actions.
 from __future__ import annotations
 
 import json
-import time
 
 from utils.logger import log_info
-from src.engine.quest_executor import run_step_with_feedback
+from src.quest_executor import run_steps
 
 
 class QuestExecutor:
@@ -29,8 +28,9 @@ class QuestExecutor:
     def run(self) -> None:
         """Run the quest, executing each step in order."""
         log_info("[QUEST EXECUTOR] Starting quest sequence...")
-        for i, step in enumerate(self.steps, start=1):
-            log_info(f"[QUEST EXECUTOR] Executing step {i}: {step}")
-            run_step_with_feedback(step)
-            time.sleep(1)  # simulate delay between steps
+
+        def formatter(i: int, step: dict) -> str:
+            return f"[QUEST EXECUTOR] Executing step {i}: {step}"
+
+        run_steps(self.steps, log_fn=log_info, delay=1, formatter=formatter)
 


### PR DESCRIPTION
## Summary
- add `run_steps` helper to `src.quest_executor`
- use helper inside `QuestExecutor` class
- share validation and logging logic between functional and class-based executors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d43fad440833190e47ff03c0c8c8e