### PR TITLE
Add quest loader and executor logging tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test validate validate-batch-044 validate-batch-045 validate-batch-046 validate-batch-047 validate-048 validate-049
+.PHONY: install test validate validate-batch-044 validate-batch-045 validate-batch-046 validate-batch-047 validate-048 validate-049 validate-batch-051
 
 install:
 	pip install -r requirements.txt
@@ -29,4 +29,7 @@ validate-048:
 	python scripts/codex_validation_batch_048.py
 
 validate-049:
-	python scripts/codex_validation_batch_049.py
+        python scripts/codex_validation_batch_049.py
+
+validate-batch-051:
+        python scripts/codex_validation_batch_051.py

--- a/core/quest_loader.py
+++ b/core/quest_loader.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from typing import Any, List, Dict
+
+
+def load_quest_steps(path: str) -> List[Dict[str, Any]]:
+    """Return quest steps loaded from JSON ``path``.
+
+    The JSON file may contain either a list of step dictionaries or a mapping
+    with a top-level ``"steps"`` key.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        data: Any = json.load(fh)
+    if isinstance(data, dict):
+        steps = data.get("steps", [])
+    elif isinstance(data, list):
+        steps = data
+    else:
+        steps = []
+    return list(steps)

--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -97,6 +97,12 @@
 - Added tests verifying the new logger functionality.
 - Included `codex_validation_batch_049.py` and Makefile target.
 
+## ✅ Batch 051
+- Added `core.quest_loader.load_quest_steps` for reading quest files.
+- `QuestExecutor` now uses the loader and `log_info` for step output.
+- Tests cover quest loading and execution logging.
+- Added `codex_validation_batch_051.py` and Makefile target.
+
 ---
 
 To install dependencies and run validation:

--- a/scripts/codex_validation_batch_051.py
+++ b/scripts/codex_validation_batch_051.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def check_exists(path: str) -> bool:
+    p = ROOT / path
+    if p.exists():
+        print(f"[OK] {path}")
+        return True
+    print(f"[MISSING] {path}")
+    return False
+
+
+def check_contains(path: str, text: str) -> bool:
+    file_path = ROOT / path
+    if not file_path.exists():
+        print(f"[MISSING FILE] {path}")
+        return False
+    if text in file_path.read_text():
+        print(f"[OK] {text}")
+        return True
+    print(f"[MISSING] {text}")
+    return False
+
+
+def main() -> None:
+    required_files = [
+        "core/quest_loader.py",
+        "src/execution/quest_executor.py",
+        "tests/test_quest_loader.py",
+        "tests/test_quest_executor.py",
+        "docs/batch_summary.md",
+        "Makefile",
+    ]
+
+    print("Validating required files:\n")
+    missing_files = [f for f in required_files if not check_exists(f)]
+
+    print("\nChecking quest executor for loader usage:\n")
+    loader_missing = 0 if check_contains("src/execution/quest_executor.py", "load_quest_steps") else 1
+    logger_missing = 0 if check_contains("src/execution/quest_executor.py", "log_info") else 1
+
+    print("\nChecking Makefile target:\n")
+    target_missing = 0 if check_contains("Makefile", "validate-batch-051") else 1
+
+    print("\nChecking batch summary for entry:\n")
+    summary_missing = 0 if check_contains("docs/batch_summary.md", "Batch 051") else 1
+
+    total_missing = len(missing_files) + loader_missing + logger_missing + target_missing + summary_missing
+
+    print("\nValidation summary:")
+    print(f"  Missing files: {len(missing_files)}")
+    print(f"  Missing loader usage: {loader_missing}")
+    print(f"  Missing logger usage: {logger_missing}")
+    print(f"  Missing make target: {target_missing}")
+    print(f"  Missing summary entry: {summary_missing}")
+
+    if total_missing:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/execution/quest_executor.py
+++ b/src/execution/quest_executor.py
@@ -7,8 +7,7 @@ in-game actions.
 
 from __future__ import annotations
 
-import json
-
+from core.quest_loader import load_quest_steps
 from utils.logger import log_info
 from src.quest_executor import run_steps
 
@@ -18,12 +17,7 @@ class QuestExecutor:
 
     def __init__(self, quest_path: str) -> None:
         self.quest_path = quest_path
-        self.steps = self.load_steps()
-
-    def load_steps(self) -> list[dict]:
-        """Load quest step dictionaries from ``quest_path``."""
-        with open(self.quest_path, "r", encoding="utf-8") as file:
-            return json.load(file)
+        self.steps = load_quest_steps(self.quest_path)
 
     def run(self) -> None:
         """Run the quest, executing each step in order."""

--- a/tests/test_quest_executor.py
+++ b/tests/test_quest_executor.py
@@ -24,3 +24,28 @@ def test_execute_quest_order(capsys):
     assert lines == expected_lines
     assert status == {"in_progress": False, "completed": True, "failed": False}
 
+
+def test_quest_executor_logs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    import importlib
+    import utils.logger as base_logger
+
+    base_logger.logger.handlers.clear()
+    importlib.reload(base_logger)
+
+    import src.execution.quest_executor as qe
+    importlib.reload(qe)
+
+    quest_file = tmp_path / "quest.json"
+    quest_file.write_text("[{\"type\": \"dialogue\"}]")
+
+    executor = qe.QuestExecutor(str(quest_file))
+    executor.run()
+
+    log_file = tmp_path / "logs" / "app.log"
+    assert log_file.exists(), "log file not created"
+    contents = log_file.read_text()
+    assert "[QUEST EXECUTOR] Starting quest sequence..." in contents
+    assert "Executing step 1" in contents
+
+

--- a/tests/test_quest_loader.py
+++ b/tests/test_quest_loader.py
@@ -1,0 +1,13 @@
+import json
+
+from core.quest_loader import load_quest_steps
+
+
+def test_load_quest_steps(tmp_path):
+    data = {"steps": [{"type": "move"}, {"type": "talk"}]}
+    path = tmp_path / "quest.json"
+    path.write_text(json.dumps(data))
+
+    steps = load_quest_steps(str(path))
+    assert steps == data["steps"]
+


### PR DESCRIPTION
## Summary
- implement `core.quest_loader.load_quest_steps`
- update `QuestExecutor` to use loader and `log_info`
- extend quest executor tests with logging check
- add quest loader unit test
- include validation script and Makefile target
- document Batch 051 changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d4c8c62ac83319d9d19333904fcb3