### PR TITLE
Fix Ruff linting issues

### DIFF
--- a/config/profession_config.py
+++ b/config/profession_config.py
@@ -1,5 +1,7 @@
 """Default profession skill requirements and trainer locations."""
 
+from utils.load_trainers import load_trainers
+
 REQUIRED_SKILLS = {
     "Artisan": ["crafting_artisan_novice"],
     "Marksman": ["combat_marksman_novice"],
@@ -11,8 +13,6 @@ REQUIRED_SKILLS = {
     "Pistoleer": ["combat_pistoleer_novice"],
     "Carbineer": ["combat_carbineer_novice"],
 }
-
-from utils.load_trainers import load_trainers
 
 
 def _primary(entries):

--- a/src/main.py
+++ b/src/main.py
@@ -29,10 +29,6 @@ from src.movement.agent_mover import MovementAgent
 from src.movement.movement_profiles import patrol_route  # noqa: F401
 from src.training.trainer_visit import visit_trainer  # noqa: F401
 
-MovementAgent
-patrol_route
-visit_trainer
-
 from android_ms11.modes import (
     quest_mode,
     profession_mode,

--- a/src/quest_executor.py
+++ b/src/quest_executor.py
@@ -41,7 +41,11 @@ def run_steps(
     """
 
     if formatter is None:
-        formatter = lambda i, s: f"\u27A1\uFE0F Step {i}: {s.get('type') if isinstance(s, dict) else s}"
+        def _default_formatter(index: int, step: dict) -> str:
+            action = step.get('type') if isinstance(step, dict) else step
+            return f"\u27A1\uFE0F Step {index}: {action}"
+
+        formatter = _default_formatter
 
     for i, step in enumerate(steps, start=1):
         log_fn(formatter(i, step))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import types
+from pathlib import Path
+import pytest
 
 try:
     import rich  # noqa: F401
@@ -74,9 +76,6 @@ if 'yaml' not in sys.modules:
     yaml_module.safe_load = safe_load
     sys.modules['yaml'] = yaml_module
 
-import os
-from pathlib import Path
-import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,4 +1,5 @@
 import importlib.util
+import importlib
 import sys
 import types
 from pathlib import Path
@@ -18,17 +19,16 @@ _core_pkg.constants = _constants
 sys.modules["core"] = _core_pkg
 sys.modules["core.constants"] = _constants
 
-from core.constants import (
-    STATUS_COMPLETED,
-    STATUS_FAILED,
-    STATUS_IN_PROGRESS,
-    STATUS_NOT_STARTED,
-    STATUS_UNKNOWN,
-    STATUS_EMOJI_MAP,
-    STATUS_NAME_FROM_EMOJI,
-    VALID_STATUS_EMOJIS,
-    __all__,
-)
+constants = importlib.import_module("core.constants")
+STATUS_COMPLETED = constants.STATUS_COMPLETED
+STATUS_FAILED = constants.STATUS_FAILED
+STATUS_IN_PROGRESS = constants.STATUS_IN_PROGRESS
+STATUS_NOT_STARTED = constants.STATUS_NOT_STARTED
+STATUS_UNKNOWN = constants.STATUS_UNKNOWN
+STATUS_EMOJI_MAP = constants.STATUS_EMOJI_MAP
+STATUS_NAME_FROM_EMOJI = constants.STATUS_NAME_FROM_EMOJI
+VALID_STATUS_EMOJIS = constants.VALID_STATUS_EMOJIS
+__all__ = constants.__all__
 
 # Clean up our temporary stubs so other tests use the real package
 if _prev_constants is not None:

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -2,8 +2,6 @@ import pytest
 
 import core.legacy_dashboard as legacy_dashboard
 import core.unified_dashboard as unified_dashboard
-import core.quest_state as qs
-import core.themepark_tracker as tp
 from core.constants import STATUS_EMOJI_MAP
 from core.utils.render_progress_bar import render_progress_bar
 from rich.console import Console

--- a/tests/test_discord_relay.py
+++ b/tests/test_discord_relay.py
@@ -1,5 +1,4 @@
 import sys
-import sys
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 import types

--- a/tests/test_game_bridge.py
+++ b/tests/test_game_bridge.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+from game_bridge import GameBridge
 
 
 def fake_run_coroutine_threadsafe(coro, loop):
@@ -7,10 +8,6 @@ def fake_run_coroutine_threadsafe(coro, loop):
     fut = MagicMock()
     fut.result.return_value = result
     return fut
-
-
-from game_bridge import GameBridge
-
 
 def _setup_relay():
     relay = MagicMock()

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -2,6 +2,7 @@ import sys
 import types
 from PIL import Image
 import pytesseract
+import importlib
 sys.modules['cv2'] = types.SimpleNamespace(COLOR_RGB2BGR=None, cvtColor=lambda img, flag: img)
 fake_np = types.ModuleType('numpy')
 fake_np.array = lambda x: x
@@ -13,8 +14,7 @@ sys.modules['numpy'] = fake_np
 sys.modules['pyautogui'] = types.SimpleNamespace(
     screenshot=lambda *a, **k: Image.new("RGB", (100, 100), color="white")
 )
-
-from src.vision.ocr import screen_text
+screen_text = importlib.import_module("src.vision.ocr").screen_text
 
 
 def test_screen_text_capture(monkeypatch):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -28,8 +28,8 @@ def test_debug_mode_replays_logs(monkeypatch, capsys):
     monkeypatch.setattr(runner, "DEFAULT_LOG_PATH", "ams11.log", raising=False)
     runner.main()
     captured = capsys.readouterr()
-    for l in lines:
-        assert l in captured.out
+    for line in lines:
+        assert line in captured.out
 
 
 def test_run_mode_dispatches(monkeypatch):

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,6 +1,7 @@
 import sys
 import time
 from types import ModuleType
+import importlib
 
 
 # Provide fake OCR module before importing StateManager
@@ -13,7 +14,7 @@ sys.modules["src.vision.ocr"] = fake_ocr
 if "src.vision" in sys.modules:
     sys.modules["src.vision"].ocr = fake_ocr
 
-from src.state.state_manager import StateManager
+StateManager = importlib.import_module("src.state.state_manager").StateManager
 
 
 def test_state_manager_callbacks(monkeypatch):

--- a/tests/test_story_generator.py
+++ b/tests/test_story_generator.py
@@ -1,6 +1,7 @@
 import sys
 from unittest.mock import MagicMock, patch, ANY
 import types
+import importlib
 
 sys.modules['transformers'] = types.ModuleType('transformers')
 sys.modules['transformers'].pipeline = lambda *a, **k: None
@@ -11,7 +12,7 @@ sys.modules['langchain.llms'] = types.ModuleType('langchain.llms')
 sys.modules['langchain.llms'].HuggingFacePipeline = object
 
 
-from src.story_generator import generate_story
+generate_story = importlib.import_module("src.story_generator").generate_story
 
 
 @patch('src.story_generator.LLMChain')

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from utils.get_trainer_location import get_trainer_location
 from utils.load_trainers import load_trainers
 from src.training.trainer_visit import visit_trainer
+import logging
 
 
 class DummyAgent:
@@ -25,9 +26,6 @@ def test_train_with_npc(capfd):
 def test_get_trainer_location():
     result = get_trainer_location("artisan", "tatooine", "mos_eisley")
     assert result == ("Artisan Trainer", 3432, -4795)
-
-
-import logging
 
 
 def test_visit_trainer_found(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- fix E402 by moving imports to top of files
- replace lambda formatter with named function in quest executor
- clean up unused imports and rename ambiguous variable
- update tests to use dynamic imports

## Testing
- `ruff check`

------
https://chatgpt.com/codex/tasks/task_b_686d4fe13af083318385d3424a87ad88