### PR TITLE
Replace prints with log_info in automator

### DIFF
--- a/src/automation/automator.py
+++ b/src/automation/automator.py
@@ -2,7 +2,7 @@ import time
 
 from src.vision.ocr import capture_screen, extract_text
 from src.vision.states import detect_state, handle_state
-from utils.logger import save_screenshot, log_ocr_text
+from utils.logger import save_screenshot, log_ocr_text, log_info
 from . import mode_manager
 from .quest_path import visit_trainer_if_needed
 
@@ -14,12 +14,12 @@ def _questing_behavior() -> None:
     state = detect_state(text)
 
     if state:
-        print(f"[MATCHED STATE] {state}")
+        log_info(f"[MATCHED STATE] {state}")
         save_screenshot()
         log_ocr_text(text)
         handle_state(state)
     else:
-        print("[NO MATCH] Continuing scan...")
+        log_info("[NO MATCH] Continuing scan...")
         visit_trainer_if_needed()
 
 
@@ -42,7 +42,7 @@ MODE_BEHAVIORS = {
 
 def run_state_monitor_loop(delay: float = 2.0, iterations: int | None = None) -> None:
     """Run the state monitor loop for ``iterations`` cycles or indefinitely."""
-    print("[AUTOMATOR] Starting screen state detection loop.")
+    log_info("[AUTOMATOR] Starting screen state detection loop.")
     count = 0
     while iterations is None or count < iterations:
         behavior = MODE_BEHAVIORS.get(mode_manager.current_mode, _questing_behavior)


### PR DESCRIPTION
## Summary
- use `utils.logger.log_info` in the automator
- switch questing and monitor loop messages to `log_info`

## Testing
- `pytest -q`
- `pytest -k automator -q`


------
https://chatgpt.com/codex/tasks/task_b_686dc9dbf9f88331a1a8c024a15e5cbd