### PR TITLE
Refactor profession logger to share configuration

### DIFF
--- a/profession_logic/utils/logger.py
+++ b/profession_logic/utils/logger.py
@@ -5,17 +5,12 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from core.logging_config import configure_logger
+
 DEFAULT_LOG_PATH = Path("logs/profession_logic.log")
 
 
 def get_logger(name: str = "profession_logic", log_path: Path = DEFAULT_LOG_PATH) -> logging.Logger:
-    """Return a configured logger writing to ``log_path``."""
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    logger = logging.getLogger(name)
-    if not logger.handlers:
-        handler = logging.FileHandler(log_path, encoding="utf-8")
-        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        logger.setLevel(logging.INFO)
+    """Return the shared logger configured for ``log_path``."""
+    logger = configure_logger(log_file=str(log_path))
     return logger


### PR DESCRIPTION
## Summary
- import `configure_logger` in `profession_logic/utils/logger.py`
- delegate logger setup to the centralized helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e00fc75c08331830a50bc73b8239e