### PR TITLE
Fix repeated logger configuration

### DIFF
--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 
 
 DEFAULT_LOG_FILE = os.path.join("logs", "app.log")
@@ -23,9 +22,8 @@ def configure_logger(
     os.makedirs(os.path.dirname(warning_file), exist_ok=True)
 
     logger = logging.getLogger("ms11")
-    if logger.handlers:
-        return logger
-    logger.setLevel(logging.INFO)
+    if logger.level == logging.NOTSET:
+        logger.setLevel(logging.INFO)
 
     formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
 


### PR DESCRIPTION
## Summary
- remove an unused `warnings` import
- continue configuring the logger even if other handlers exist
- avoid resetting level and handlers on subsequent calls

## Testing
- `ruff check core/logging_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e191ef9348331babc6e51b4a5cc7c