### PR TITLE
Add duplicate handler check for logging_config

### DIFF
--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -24,3 +24,26 @@ def test_configure_logger_creates_files(tmp_path, monkeypatch):
     assert warn_file.exists(), "Warning log was not created"
     assert "hello" in log_file.read_text()
     assert "watch out" in warn_file.read_text()
+
+
+def test_logger_reuse_prevents_duplicate_handlers(tmp_path, monkeypatch):
+    """Calling configure_logger twice should not add handlers twice."""
+    monkeypatch.chdir(tmp_path)
+    reload(logging_config)
+
+    base_logger = logging.getLogger("ms11")
+    for h in list(base_logger.handlers):
+        base_logger.removeHandler(h)
+    warnings_logger = logging.getLogger("py.warnings")
+    for h in list(warnings_logger.handlers):
+        warnings_logger.removeHandler(h)
+
+    log_file = tmp_path / "logs" / "app.log"
+    warn_file = tmp_path / "logs" / "warnings.log"
+
+    logger_first = logging_config.configure_logger(str(log_file), str(warn_file))
+    first_handler_count = len(logger_first.handlers)
+
+    logger_second = logging_config.configure_logger(str(log_file), str(warn_file))
+
+    assert len(logger_second.handlers) == first_handler_count


### PR DESCRIPTION
## Summary
- extend `test_logging_config` with a new test `test_logger_reuse_prevents_duplicate_handlers`
- ensure calling `configure_logger` twice does not add handlers again

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e1a1a820c8331b4ee2b1969aaaa35