### PR TITLE
Add Codex Validation Batch 059

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test validate validate-batch-044 validate-batch-045 validate-batch-046 validate-batch-047 validate-048 validate-049 validate-batch-051 validate-batch-052 validate-batch-055 validate-batch-056
+.PHONY: install test validate validate-batch-044 validate-batch-045 validate-batch-046 validate-batch-047 validate-048 validate-049 validate-batch-051 validate-batch-052 validate-batch-055 validate-batch-056 validate-batch-059
 
 install:
 	pip install -r requirements.txt
@@ -41,7 +41,10 @@ validate-batch-055:
 	python scripts/codex_validation_batch_055.py
 
 validate-batch-056:
-        python scripts/codex_validation_batch_056.py
+	python scripts/codex_validation_batch_056.py
 
 validate-batch-058:
-        python scripts/codex_validation_batch_058.py
+	python scripts/codex_validation_batch_058.py
+
+validate-batch-059:
+	python scripts/codex_validation_batch_059.py

--- a/codex_validation_check.py
+++ b/codex_validation_check.py
@@ -38,6 +38,7 @@ def main() -> None:
         "scripts/codex_validation_batch_055.py",
         "scripts/codex_validation_batch_056.py",
         "scripts/codex_validation_batch_058.py",
+        "scripts/codex_validation_batch_059.py",
     ]
 
     print("Validating required files:\n")

--- a/scripts/codex_validation_batch_059.py
+++ b/scripts/codex_validation_batch_059.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+REQUIRED_FILES = [
+    "profession_logic/utils/logger.py",
+    "tests/test_logger.py",
+    "tests/test_logger_usage.py",
+    "scripts/codex_validation_batch_059.py",
+]
+
+
+def main() -> None:
+    missing = [f for f in REQUIRED_FILES if not (ROOT / f).is_file()]
+    if missing:
+        print("[BATCH 059] \u274c Missing files:", missing)
+        sys.exit(1)
+    print("[BATCH 059] \u2705 All files validated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add batch 059 validation script
- reference new batch in global validation check
- expose `validate-batch-059` target in Makefile

## Testing
- `python scripts/codex_validation_batch_059.py`
- `python codex_validation_check.py`
- `make validate-batch-059`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686edf56674c8331aa4e11afa32da5d5