### PR TITLE
Add additional logging helpers

### DIFF
--- a/profession_logic/utils/logger.py
+++ b/profession_logic/utils/logger.py
@@ -11,3 +11,18 @@ logger = configure_logger(name="profession_logic", log_file="logs/profession_log
 def log_info(message: str) -> None:
     """Log ``message`` using the profession logger."""
     logger.info(message)
+
+
+def log_warning(message: str) -> None:
+    """Log ``message`` with warning level using the profession logger."""
+    logger.warning(message)
+
+
+def log_error(message: str) -> None:
+    """Log ``message`` with error level using the profession logger."""
+    logger.error(message)
+
+
+def log_debug(message: str) -> None:
+    """Log ``message`` with debug level using the profession logger."""
+    logger.debug(message)


### PR DESCRIPTION
## Summary
- add warning, error and debug logging helpers in profession logger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686f3f3cc45883318b9c4d24dfcbf67d