### PR TITLE
Add configurable log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ The application writes several logs under the `logs/` directory:
 - `logs/training_log.txt` &ndash; entries recorded by the trainer navigator.
 
 Running the test suite also writes logs to this directory.
+Set the ``LOG_LEVEL`` environment variable (e.g. ``DEBUG``) to control log verbosity. The default level is ``INFO``.
 
 ## Running Tests
 

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -3,8 +3,12 @@ import os
 from pathlib import Path
 
 
-def configure_logger(name: str = "default", log_file: str | None = None) -> logging.Logger:
-    """Return a logger with optional file output.
+def configure_logger(
+    name: str = "default",
+    log_file: str | None = None,
+    level: int | str | None = None,
+) -> logging.Logger:
+    """Return a logger with optional file output and configurable level.
 
     Reusing the same ``name`` ensures handlers are only added once.
     """
@@ -12,7 +16,13 @@ def configure_logger(name: str = "default", log_file: str | None = None) -> logg
     if getattr(logger, "_configured", False):
         return logger
 
-    logger.setLevel(logging.INFO)
+    if level is None:
+        level = os.getenv("LOG_LEVEL", "INFO")
+    if isinstance(level, str):
+        level = logging.getLevelName(level.upper())
+        if not isinstance(level, int):
+            level = logging.INFO
+    logger.setLevel(level)
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 
     console_handler = logging.StreamHandler()

--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -189,3 +189,8 @@ make validate-batch-058
 - `profession_logic.utils.logger` relies on this default path.
 - Tests mock different instances to confirm the log file names.
 - Added `scripts/codex_validation_batch_061.py` and a `validate-batch-061` Makefile target.
+
+### Batch 062 – Log Level Control
+
+- `configure_logger` accepts an optional `level` parameter and reads the `LOG_LEVEL` environment variable.
+- Users can adjust verbosity by setting the log level (default `INFO`).

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -33,3 +33,21 @@ def test_logger_reuse_prevents_duplicate_handlers(tmp_path, monkeypatch):
     logger_second = logging_config.configure_logger(log_file=str(log_file))
 
     assert len(logger_second.handlers) == first_handler_count
+
+
+def test_configure_logger_respects_level(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+    reload(logging_config)
+
+    base_logger = logging.getLogger("ms11_level")
+    for h in list(base_logger.handlers):
+        base_logger.removeHandler(h)
+
+    logger = logging_config.configure_logger(name="ms11_level")
+    assert logger.level == logging.WARNING
+
+    logger_param = logging_config.configure_logger(
+        name="ms11_param", level=logging.DEBUG
+    )
+    assert logger_param.level == logging.DEBUG


### PR DESCRIPTION
## Summary
- allow overriding log level via LOG_LEVEL env var or `configure_logger(..., level=...)`
- document new environment variable in README
- note log level option in batch summary
- test that configure_logger honors custom level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873365460b48331bf7a67148e6c750a