### PR TITLE
Clarify logging output

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ separate logs when running multiple instances:
 BOT_INSTANCE_NAME=MS11_Alpha python src/main.py --mode quest
 # creates logs/MS11_Alpha.log
 ```
+All log levels, including warnings, are written to this file. The application
+does not create a separate `.warnings.log` file.
 
 Set `LOG_LEVEL` to control how verbose the output is. Levels follow the
 standard Python logging values such as `DEBUG` or `INFO` (the default):
@@ -734,6 +736,7 @@ start_travel_to_trainer(trainer)
 The application writes several logs under the `logs/` directory:
 
 - `logs/<instance>.log` &ndash; general runtime messages produced by `start_log()`.
+- *No `warnings.log` is created; warnings are included in the main log.*
 - `logs/quest_selections.log` &ndash; history of quests chosen via the CLI.
 - `logs/step_journal.log` &ndash; success/failure records from step validation.
 - `logs/session_*.json` &ndash; detailed step traces and summaries for each session.


### PR DESCRIPTION
## Summary
- explain that warnings share the same logfile as other messages
- note the absence of a separate `warnings.log` file

## Testing
- `make validate`

------
https://chatgpt.com/codex/tasks/task_b_688076028b1083319034b534e5e3ab7f