### PR TITLE
Document LOG_RETENTION_DAYS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ standard Python logging values such as `DEBUG` or `INFO` (the default):
 LOG_LEVEL=DEBUG python src/main.py --mode quest
 ```
 
+Set `LOG_RETENTION_DAYS` to configure how many days to retain timestamped log files. Old files are removed whenever `configure_logger()` runs.
+
+```bash
+LOG_RETENTION_DAYS=7 python src/main.py
+```
+
 ## Automation Modes
 Select a runtime mode when starting the automation. The ``--mode`` option
 controls which behavior module is activated. Available modes include:


### PR DESCRIPTION
## Summary
- document LOG_RETENTION_DAYS retention behavior in README
- show how cleanup happens when `configure_logger()` runs
- add example usage

## Testing
- `pytest -q`
- `python codex_validation_check.py`


------
https://chatgpt.com/codex/tasks/task_b_6880881370b48331b8a50fc6b93b3d05