### PR TITLE
Update log retention constants

### DIFF
--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -3,11 +3,11 @@ import os
 from pathlib import Path
 from datetime import datetime, timedelta
 
-MAX_LOG_FILES = 10
-"""Maximum number of log files to retain in the logs directory."""
+MAX_LOG_FILES = 20
+"""Maximum number of log files to retain in the logs directory (default: 20)."""
 
-MAX_LOG_AGE_DAYS = 30
-"""Maximum age in days before a log file is deleted."""
+MAX_LOG_AGE_DAYS = 14
+"""Maximum age in days before a log file is deleted (default: 14)."""
 
 LOG_RETENTION_ENV = "LOG_RETENTION_DAYS"
 """Environment variable that overrides ``MAX_LOG_AGE_DAYS`` if set."""


### PR DESCRIPTION
## Summary
- increase `MAX_LOG_FILES` to 20
- lower `MAX_LOG_AGE_DAYS` to 14
- adjust docstrings to match the new defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68808f51e4e88331b798a488197919df