### PR TITLE
Implement chat listener loop

### DIFF
--- a/network/chat_listener.py
+++ b/network/chat_listener.py
@@ -7,9 +7,13 @@ def listen_for_chat(callback):
 
     def chat_loop():
         time.sleep(0.1)
-        # Placeholder for real chat input logic
-        pass
+        while True:
+            try:
+                line = input("")
+            except EOFError:
+                break
+            callback(line)
 
     thread = threading.Thread(target=chat_loop, daemon=True)
     thread.start()
-    thread.join(0.2)
+    # Intentionally do not join so the listener stays active

--- a/tests/test_chat_listener.py
+++ b/tests/test_chat_listener.py
@@ -5,6 +5,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
 from network.chat_listener import listen_for_chat
+import time
 
 
 def test_callback_receives_input(monkeypatch):
@@ -13,6 +14,16 @@ def test_callback_receives_input(monkeypatch):
     def callback(text):
         results.append(text)
 
-    monkeypatch.setattr('builtins.input', lambda _: "Test message")
+    called = False
+
+    def fake_input(_):
+        nonlocal called
+        if not called:
+            called = True
+            return "Test message"
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", fake_input)
     listen_for_chat(callback)
-    assert results == []  # Thread may not run before assertion
+    time.sleep(0.2)
+    assert results == ["Test message"]


### PR DESCRIPTION
## Summary
- forward chat lines to callback in `chat_listener`
- keep chat listener thread alive
- ensure test waits for message and asserts callback

## Testing
- `pytest -k chat_listener -q`


------
https://chatgpt.com/codex/tasks/task_b_6885dda7c0588331975fdecf2776d3bd