### PR TITLE
Fix path resolution in codex batch 065

### DIFF
--- a/scripts/codex_validation_batch_065.py
+++ b/scripts/codex_validation_batch_065.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import sys
 
+ROOT = Path(__file__).resolve().parent.parent
+
 REQUIRED = [
     "vision/capture_screen.py",
     "vision/ocr_engine.py",
@@ -12,7 +14,7 @@ REQUIRED = [
 
 
 def main() -> None:
-    missing = [f for f in REQUIRED if not Path(f).is_file()]
+    missing = [f for f in REQUIRED if not (ROOT / f).is_file()]
     if missing:
         print(f"[BATCH 065] \u274c Missing files: {missing}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- resolve project root in codex_validation_batch_065
- check required files relative to this root so the script can run from any path

## Testing
- `pytest -q`
- `python scripts/codex_validation_batch_065.py`
- `python Project-MorningStar/scripts/codex_validation_batch_065.py` from parent dir

------
https://chatgpt.com/codex/tasks/task_b_6885e2867e408331bd8db99cd8260d07