### PR TITLE
Add OCR utils whitespace test

### DIFF
--- a/scripts/codex_validation_batch_065.py
+++ b/scripts/codex_validation_batch_065.py
@@ -10,6 +10,7 @@ REQUIRED = [
     "network/chat_listener.py",
     "tests/test_ocr_engine.py",
     "tests/test_chat_listener.py",
+    "tests/test_ocr_utils.py",
 ]
 
 

--- a/tests/test_ocr_utils.py
+++ b/tests/test_ocr_utils.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from vision.ocr_utils import clean_ocr_text
+
+
+def test_clean_ocr_text_collapses_whitespace():
+    text = " Hello\n\nWorld  from  OCR  "
+    assert clean_ocr_text(text) == "Hello World from OCR"


### PR DESCRIPTION
## Summary
- test `clean_ocr_text` handling of newlines and spaces
- ensure presence of the test in batch-065 validation script

## Testing
- `pytest -q tests/test_ocr_utils.py`
- `pytest -q`
- `python scripts/codex_validation_batch_065.py`

------
https://chatgpt.com/codex/tasks/task_b_6885e540e5a8833198d84fc7786866f9