### PR TITLE
Skip OCR engine tests when Tesseract unavailable

### DIFF
--- a/tests/test_ocr_engine.py
+++ b/tests/test_ocr_engine.py
@@ -1,8 +1,18 @@
 import os
 import sys
 
+import pytest
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
+
+pytest.importorskip("pytesseract")
+import pytesseract
+
+try:
+    pytesseract.get_tesseract_version()
+except Exception:
+    pytest.skip("Tesseract binary is not installed", allow_module_level=True)
 
 from vision.ocr_engine import run_ocr
 from PIL import Image


### PR DESCRIPTION
## Summary
- avoid failing OCR engine tests if `pytesseract` or the Tesseract binary are missing
- gracefully skip the test module when Tesseract cannot be detected

## Testing
- `pytest tests/test_ocr_engine.py -vv`
- `pytest -q --tb=short`

------
https://chatgpt.com/codex/tasks/task_b_6885eae8c02c8331be5a8d863603ea48