### PR TITLE
Return chat listener thread

### DIFF
--- a/network/chat_listener.py
+++ b/network/chat_listener.py
@@ -3,7 +3,14 @@ import time
 
 
 def listen_for_chat(callback):
-    """Start a background thread that forwards input lines to ``callback``."""
+    """Start a background thread that forwards input lines to ``callback``.
+
+    Returns
+    -------
+    threading.Thread
+        The background thread running the chat loop so callers may join or
+        otherwise manage it.
+    """
 
     def chat_loop():
         time.sleep(0.1)
@@ -17,3 +24,4 @@ def listen_for_chat(callback):
     thread = threading.Thread(target=chat_loop, daemon=True)
     thread.start()
     # Intentionally do not join so the listener stays active
+    return thread

--- a/tests/test_chat_listener.py
+++ b/tests/test_chat_listener.py
@@ -5,7 +5,6 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
 from network.chat_listener import listen_for_chat
-import time
 
 
 def test_callback_receives_input(monkeypatch):
@@ -24,6 +23,6 @@ def test_callback_receives_input(monkeypatch):
         raise EOFError
 
     monkeypatch.setattr("builtins.input", fake_input)
-    listen_for_chat(callback)
-    time.sleep(0.2)
+    thread = listen_for_chat(callback)
+    thread.join(timeout=1)
     assert results == ["Test message"]


### PR DESCRIPTION
## Summary
- return the thread created by `listen_for_chat`
- adjust `test_chat_listener` to join the returned thread
- document the new return value in the function docstring

## Testing
- `pytest -q tests/test_chat_listener.py`

------
https://chatgpt.com/codex/tasks/task_b_6885ebde8c4c8331b87af808848c6b1c